### PR TITLE
Add time-based revalidation tests, refactor cache-testing app, and improve DX

### DIFF
--- a/apps/cache-testing/playwright.config.ts
+++ b/apps/cache-testing/playwright.config.ts
@@ -2,10 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
     testDir: './tests',
-    fullyParallel: true,
+    fullyParallel: false,
     forbidOnly: Boolean(process.env.CI),
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    workers: 1,
     reporter: 'html',
     use: { baseURL: 'http://127.0.0.1:3000', trace: 'on-first-retry', testIdAttribute: 'data-pw' },
     projects: [

--- a/apps/cache-testing/src/app/app/no-params/dynamic-false/[slug]/page.tsx
+++ b/apps/cache-testing/src/app/app/no-params/dynamic-false/[slug]/page.tsx
@@ -1,38 +1,23 @@
 import { notFound } from 'next/navigation';
-import { normalizeSlug } from '../../../../../utils/normalize-slug';
+import { createGetData } from '../../../../../utils/create-get-data';
+import { CommonAppPage } from '../../../../../utils/common-app-page';
 
 export const dynamicParams = false;
 
+export const revalidate = 5;
+
 type PageParams = { params: { slug: string } };
 
-async function getData(slug: string): Promise<number | null> {
-    const result = await fetch(`http://localhost:8081/app/no-params/dynamic-false/${normalizeSlug(slug)}`, {
-        next: { revalidate: 10, tags: [`/app/no-params/dynamic-false/${normalizeSlug(slug)}`] },
-    });
-
-    if (!result.ok) {
-        return null;
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return null;
-    }
-
-    return parsedResult.count;
-}
+const getData = createGetData('app/no-params/dynamic-false');
 
 export default async function Index({ params }: PageParams): Promise<JSX.Element> {
-    const count = await getData(params.slug);
+    const data = await getData(params.slug);
 
-    if (typeof count === 'undefined') {
+    if (!data) {
         notFound();
     }
 
-    return (
-        <div data-pw="data" id="app/no-params/dynamic-false">
-            {count}
-        </div>
-    );
+    const { count, path, time } = data;
+
+    return <CommonAppPage count={count} path={path} revalidateAfter={revalidate * 1000} time={time} />;
 }

--- a/apps/cache-testing/src/app/app/no-params/dynamic-true/[slug]/page.tsx
+++ b/apps/cache-testing/src/app/app/no-params/dynamic-true/[slug]/page.tsx
@@ -1,38 +1,23 @@
 import { notFound } from 'next/navigation';
-import { normalizeSlug } from '../../../../../utils/normalize-slug';
+import { createGetData } from '../../../../../utils/create-get-data';
+import { CommonAppPage } from '../../../../../utils/common-app-page';
 
 export const dynamicParams = true;
 
+export const revalidate = 5;
+
 type PageParams = { params: { slug: string } };
 
-async function getData(slug: string): Promise<number | null> {
-    const result = await fetch(`http://localhost:8081/app/no-params/dynamic-true/${normalizeSlug(slug)}`, {
-        next: { revalidate: 10, tags: [`/app/no-params/dynamic-true/${normalizeSlug(slug)}`] },
-    });
-
-    if (!result.ok) {
-        return null;
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return null;
-    }
-
-    return parsedResult.count;
-}
+const getData = createGetData('app/no-params/dynamic-true');
 
 export default async function Index({ params }: PageParams): Promise<JSX.Element> {
-    const count = await getData(params.slug);
+    const data = await getData(params.slug);
 
-    if (typeof count === 'undefined') {
+    if (!data) {
         notFound();
     }
 
-    return (
-        <div data-pw="data" id="app/no-params/dynamic-true">
-            {count}
-        </div>
-    );
+    const { count, path, time } = data;
+
+    return <CommonAppPage count={count} path={path} revalidateAfter={revalidate * 1000} time={time} />;
 }

--- a/apps/cache-testing/src/app/app/with-params/dynamic-false/[slug]/page.tsx
+++ b/apps/cache-testing/src/app/app/with-params/dynamic-false/[slug]/page.tsx
@@ -1,41 +1,27 @@
 import { notFound } from 'next/navigation';
+import { createGetData } from '../../../../../utils/create-get-data';
+import { CommonAppPage } from '../../../../../utils/common-app-page';
 
 type PageParams = { params: { slug: string } };
 
 export const dynamicParams = false;
 
-async function getData(slug: string): Promise<number | null> {
-    const result = await fetch(`http://localhost:8081/app/with-params/dynamic-false/${slug}`, {
-        next: { revalidate: 10, tags: [`/app/with-params/dynamic-false/${slug}`] },
-    });
+export const revalidate = 5;
 
-    if (!result.ok) {
-        return null;
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return null;
-    }
-
-    return parsedResult.count;
-}
+const getData = createGetData('app/with-params/dynamic-false');
 
 export function generateStaticParams(): Promise<PageParams['params'][]> {
     return Promise.resolve([{ slug: '200' }, { slug: '404' }, { slug: 'alternate-200-404' }]);
 }
 
 export default async function Index({ params }: PageParams): Promise<JSX.Element> {
-    const count = await getData(params.slug);
+    const data = await getData(params.slug);
 
-    if (!count) {
+    if (!data) {
         notFound();
     }
 
-    return (
-        <div data-pw="data" id="app/with-params/dynamic-false">
-            {count}
-        </div>
-    );
+    const { count, path, time } = data;
+
+    return <CommonAppPage count={count} path={path} revalidateAfter={revalidate * 1000} time={time} />;
 }

--- a/apps/cache-testing/src/app/app/with-params/dynamic-true/[slug]/page.tsx
+++ b/apps/cache-testing/src/app/app/with-params/dynamic-true/[slug]/page.tsx
@@ -1,41 +1,27 @@
 import { notFound } from 'next/navigation';
+import { createGetData } from '../../../../../utils/create-get-data';
+import { CommonAppPage } from '../../../../../utils/common-app-page';
 
 type PageParams = { params: { slug: string } };
 
 export const dynamicParams = true;
 
-async function getData(slug: string): Promise<number | null> {
-    const result = await fetch(`http://localhost:8081/app/with-params/dynamic-true/${slug}`, {
-        next: { revalidate: 10, tags: [`/app/with-params/dynamic-true/${slug}`] },
-    });
+export const revalidate = 5;
 
-    if (!result.ok) {
-        return null;
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return null;
-    }
-
-    return parsedResult.count;
-}
+const getData = createGetData('app/with-params/dynamic-true');
 
 export function generateStaticParams(): Promise<PageParams['params'][]> {
     return Promise.resolve([{ slug: '200' }, { slug: '404' }, { slug: 'alternate-200-404' }]);
 }
 
 export default async function Index({ params }: PageParams): Promise<JSX.Element> {
-    const count = await getData(params.slug);
+    const data = await getData(params.slug);
 
-    if (!count) {
+    if (!data) {
         notFound();
     }
 
-    return (
-        <div data-pw="data" id="app/with-params/dynamic-true">
-            {count}
-        </div>
-    );
+    const { count, path, time } = data;
+
+    return <CommonAppPage count={count} path={path} revalidateAfter={revalidate * 1000} time={time} />;
 }

--- a/apps/cache-testing/src/components/cache-state-watcher.tsx
+++ b/apps/cache-testing/src/components/cache-state-watcher.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type CacheStateWatcherProps = { time: number; revalidateAfter: number };
+
+export function CacheStateWatcher({ time, revalidateAfter }: CacheStateWatcherProps): JSX.Element {
+    const [cacheState, setCacheState] = useState('');
+    const [countDown, setCountDown] = useState(0);
+
+    useEffect(() => {
+        let id = -1;
+
+        function check(): void {
+            const now = Date.now();
+
+            setCountDown(Math.max(0, Math.round((time + revalidateAfter - now) / 1000)));
+
+            if (now > time + revalidateAfter) {
+                setCacheState('stale');
+
+                return;
+            }
+
+            setCacheState('fresh');
+
+            id = requestAnimationFrame(check);
+        }
+
+        id = requestAnimationFrame(check);
+
+        return () => {
+            cancelAnimationFrame(id);
+        };
+    }, [revalidateAfter, time]);
+
+    return (
+        <div>
+            <div data-pw="prerendered-at">Prerendered at {time}</div>
+            <div data-pw="cache-state">Cache state {cacheState}</div>
+            <div data-pw="stale-in">Stale in {countDown}</div>
+        </div>
+    );
+}

--- a/apps/cache-testing/src/pages/pages/no-paths/fallback-blocking/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/no-paths/fallback-blocking/[slug].tsx
@@ -1,34 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
-import { normalizeSlug } from '../../../../utils/normalize-slug';
-import RootLayout from '../../../layout';
+import type { GetStaticPathsResult } from 'next';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
+import { CommonPagesPage } from '../../../../utils/common-pages-page';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/no-paths/fallback-blocking/${normalizeSlug(slug)}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/no-paths/fallback-blocking');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -37,14 +11,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/no-paths/fallback-blocking">
-            {count}
-        </div>
-    );
-}
-
-Index.getLayout = RootLayout;
-
-export default Index;
+export default CommonPagesPage;

--- a/apps/cache-testing/src/pages/pages/no-paths/fallback-false/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/no-paths/fallback-false/[slug].tsx
@@ -1,34 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
-import { normalizeSlug } from '../../../../utils/normalize-slug';
-import RootLayout from '../../../layout';
+import type { GetStaticPathsResult } from 'next';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
+import { CommonPagesPage } from '../../../../utils/common-pages-page';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/no-paths/fallback-false/${normalizeSlug(slug)}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/no-paths/fallback-false');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -37,14 +11,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/no-paths/fallback-false">
-            {count}
-        </div>
-    );
-}
-
-Index.getLayout = RootLayout;
-
-export default Index;
+export default CommonPagesPage;

--- a/apps/cache-testing/src/pages/pages/no-paths/fallback-true/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/no-paths/fallback-true/[slug].tsx
@@ -1,34 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
-import { normalizeSlug } from '../../../../utils/normalize-slug';
-import RootLayout from '../../../layout';
+import type { GetStaticPathsResult } from 'next';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
+import CommonPagesPage from '../fallback-blocking/[slug]';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/no-paths/fallback-true/${normalizeSlug(slug)}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/no-paths/fallback-true');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -37,14 +11,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/no-paths/fallback-true">
-            {count}
-        </div>
-    );
-}
-
-Index.getLayout = RootLayout;
-
-export default Index;
+export default CommonPagesPage;

--- a/apps/cache-testing/src/pages/pages/with-paths/fallback-blocking/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/with-paths/fallback-blocking/[slug].tsx
@@ -1,32 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import type { GetStaticPathsResult } from 'next';
+import CommonPagesPage from '../../no-paths/fallback-blocking/[slug]';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/with-paths/fallback-blocking/${slug}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/with-paths/fallback-blocking');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -39,10 +15,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-export default function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/with-paths/fallback-blocking">
-            {count}
-        </div>
-    );
-}
+export default CommonPagesPage;

--- a/apps/cache-testing/src/pages/pages/with-paths/fallback-false/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/with-paths/fallback-false/[slug].tsx
@@ -1,32 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import type { GetStaticPathsResult } from 'next';
+import CommonPagesPage from '../fallback-blocking/[slug]';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/with-paths/fallback-false/${slug}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/with-paths/fallback-false');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -39,10 +15,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-export default function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/with-paths/fallback-false">
-            {count}
-        </div>
-    );
-}
+export default CommonPagesPage;

--- a/apps/cache-testing/src/pages/pages/with-paths/fallback-true/[slug].tsx
+++ b/apps/cache-testing/src/pages/pages/with-paths/fallback-true/[slug].tsx
@@ -1,32 +1,8 @@
-import type { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import type { GetStaticPathsResult } from 'next';
+import CommonPagesPage from '../fallback-blocking/[slug]';
+import { createPagesGetStaticProps } from '../../../../utils/create-pages-get-static-props';
 
-type PageProps = { count: number };
-
-export async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
-    if (!params) {
-        throw new Error('no params');
-    }
-
-    const { slug } = params;
-
-    if (!slug || Array.isArray(slug)) {
-        throw new Error('no slug');
-    }
-
-    const result = await fetch(`http://localhost:8081/pages/with-paths/fallback-true/${slug}`);
-
-    if (!result.ok) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    const parsedResult = (await result.json()) as { count: number } | null;
-
-    if (!parsedResult) {
-        return { notFound: true, revalidate: 10 };
-    }
-
-    return { props: { count: parsedResult.count }, revalidate: 10 };
-}
+export const getStaticProps = createPagesGetStaticProps('pages/with-paths/fallback-true');
 
 export function getStaticPaths(): Promise<GetStaticPathsResult> {
     return Promise.resolve({
@@ -39,10 +15,4 @@ export function getStaticPaths(): Promise<GetStaticPathsResult> {
     });
 }
 
-export default function Index({ count }: PageProps): JSX.Element {
-    return (
-        <div data-pw="data" id="pages/with-paths/fallback-true">
-            {count}
-        </div>
-    );
-}
+export default CommonPagesPage;

--- a/apps/cache-testing/src/utils/common-app-page.tsx
+++ b/apps/cache-testing/src/utils/common-app-page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react';
+import { CacheStateWatcher } from '../components/cache-state-watcher';
+import type { PageProps } from './types';
+
+export function CommonAppPage({ count, revalidateAfter, time, path }: PageProps): JSX.Element {
+    return (
+        <div>
+            <div data-pw="data" id={path}>
+                {count}
+            </div>
+            <Suspense fallback={null}>
+                <CacheStateWatcher revalidateAfter={revalidateAfter} time={time} />
+            </Suspense>
+        </div>
+    );
+}

--- a/apps/cache-testing/src/utils/common-pages-page.tsx
+++ b/apps/cache-testing/src/utils/common-pages-page.tsx
@@ -1,0 +1,13 @@
+import { CacheStateWatcher } from '../components/cache-state-watcher';
+import type { PageProps } from './types';
+
+export function CommonPagesPage({ count, revalidateAfter, time, path }: PageProps): JSX.Element {
+    return (
+        <div>
+            <div data-pw="data" id={path}>
+                {count}
+            </div>
+            <CacheStateWatcher revalidateAfter={revalidateAfter} time={time} />
+        </div>
+    );
+}

--- a/apps/cache-testing/src/utils/create-get-data.ts
+++ b/apps/cache-testing/src/utils/create-get-data.ts
@@ -1,0 +1,26 @@
+import { normalizeSlug } from './normalize-slug';
+import type { PageProps } from './types';
+
+export function createGetData(path: string, revalidate?: number) {
+    return async function getData(slug: string): Promise<Omit<PageProps, 'revalidateAfter'> | null> {
+        const pathAndTag = `/${path}/${normalizeSlug(slug)}`;
+
+        const result = await fetch(`http://localhost:8081${pathAndTag}`, {
+            next: { revalidate, tags: [pathAndTag, 'whole-app-route'] },
+        });
+
+        if (!result.ok) {
+            return null;
+        }
+
+        const parsedResult = (await result.json()) as { count: number } | null;
+
+        if (!parsedResult) {
+            return null;
+        }
+
+        const time = Date.now();
+
+        return { count: parsedResult.count, path, time };
+    };
+}

--- a/apps/cache-testing/src/utils/create-pages-get-static-props.ts
+++ b/apps/cache-testing/src/utils/create-pages-get-static-props.ts
@@ -1,0 +1,34 @@
+import type { GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import type { PageProps } from './types';
+
+const revalidate = 5;
+
+export function createPagesGetStaticProps(path: string) {
+    return async function getStaticProps({ params }: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
+        if (!params) {
+            throw new Error('no params');
+        }
+
+        const { slug } = params;
+
+        if (!slug || Array.isArray(slug)) {
+            throw new Error('no slug');
+        }
+
+        const result = await fetch(`http://localhost:8081/${path}/${slug}`);
+
+        if (!result.ok) {
+            return { notFound: true, revalidate };
+        }
+
+        const parsedResult = (await result.json()) as { count: number } | null;
+
+        if (!parsedResult) {
+            return { notFound: true, revalidate };
+        }
+
+        const time = Date.now();
+
+        return { props: { count: parsedResult.count, revalidateAfter: revalidate * 1000, time, path }, revalidate };
+    };
+}

--- a/apps/cache-testing/src/utils/types.ts
+++ b/apps/cache-testing/src/utils/types.ts
@@ -1,0 +1,1 @@
+export type PageProps = { count: number; time: number; revalidateAfter: number; path: string };

--- a/apps/cache-testing/tests/app.spec.ts
+++ b/apps/cache-testing/tests/app.spec.ts
@@ -1,70 +1,115 @@
 import { test, expect } from '@playwright/test';
 
-const urls = [
-    '/app/with-params/dynamic-true/200',
-    // '/app/with-params/dynamic-false/200', // this fails in native next.js cache
-    '/app/no-params/dynamic-true/200',
-    '/app/no-params/dynamic-false/200',
-];
+test.describe('on-demand revalidation', () => {
+    const urls = [
+        '/app/with-params/dynamic-true/200',
+        // '/app/with-params/dynamic-false/200', // this fails in native next.js cache
+        '/app/no-params/dynamic-true/200',
+        '/app/no-params/dynamic-false/200',
+    ];
 
-for (const url of urls) {
-    test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
-        await page.goto(url);
+    for (const url of urls) {
+        test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
+            await page.goto(url);
 
-        await page.getByTestId('revalidate-button-path').click();
+            await page.getByTestId('revalidate-button-path').click();
 
-        await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
 
-        await page.reload();
+            await page.reload();
 
-        let val = (await page.getByTestId('data').innerText()).valueOf();
+            let val = (await page.getByTestId('data').innerText()).valueOf();
 
-        await page.reload();
+            await page.reload();
 
-        // Page should not have changed after reload if revalidation button was not clicked
+            // Page should not have changed after reload if revalidation button was not clicked
 
-        await expect(page.getByTestId('data')).toHaveText(val);
+            await expect(page.getByTestId('data')).toHaveText(val);
 
-        // Click on revalidate by path button
+            // Click on revalidate by path button
 
-        await page.getByTestId('revalidate-button-path').click();
+            await page.getByTestId('revalidate-button-path').click();
 
-        await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
 
-        await page.reload();
+            await page.reload();
 
-        // Page should have changed after reload if revalidation button was clicked
+            // Page should have changed after reload if revalidation button was clicked
 
-        await expect(page.getByTestId('data')).not.toHaveText(val);
+            await expect(page.getByTestId('data')).not.toHaveText(val);
 
-        val = (await page.getByTestId('data').innerText()).valueOf();
+            val = (await page.getByTestId('data').innerText()).valueOf();
 
-        await page.reload();
+            await page.reload();
 
-        // Page should not have changed after reload if revalidation button was not clicked
+            // Page should not have changed after reload if revalidation button was not clicked
 
-        await expect(page.getByTestId('data')).toHaveText(val);
+            await expect(page.getByTestId('data')).toHaveText(val);
 
-        // Tag revalidation button
+            // Tag revalidation button
 
-        // Click on revalidate by tag button
+            // Click on revalidate by tag button
 
-        await page.getByTestId('revalidate-button-tag').click();
+            await page.getByTestId('revalidate-button-tag').click();
 
-        await expect(page.getByTestId('is-revalidated-by-tag')).toContainText('Revalidated at');
+            await expect(page.getByTestId('is-revalidated-by-tag')).toContainText('Revalidated at');
 
-        await page.reload();
+            await page.reload();
 
-        // Page should have changed after reload if revalidation button was clicked
+            // Page should have changed after reload if revalidation button was clicked
 
-        await expect(page.getByTestId('data')).not.toHaveText(val);
+            await expect(page.getByTestId('data')).not.toHaveText(val);
 
-        val = (await page.getByTestId('data').innerText()).valueOf();
+            val = (await page.getByTestId('data').innerText()).valueOf();
 
-        await page.reload();
+            await page.reload();
 
-        // Page should not have changed after reload if revalidation button was not clicked
+            // Page should not have changed after reload if revalidation button was not clicked
 
-        await expect(page.getByTestId('data')).toHaveText(val);
-    });
-}
+            await expect(page.getByTestId('data')).toHaveText(val);
+        });
+    }
+});
+
+test.describe('time based revalidation', () => {
+    const urls = [
+        '/app/with-params/dynamic-true/200',
+        // '/app/with-params/dynamic-false/200', // this fails in native next.js cache
+        '/app/no-params/dynamic-true/200',
+        '/app/no-params/dynamic-false/200',
+    ];
+
+    for (const url of urls) {
+        test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
+            await page.goto('/pages/no-paths/fallback-blocking/200');
+
+            await page.getByTestId('revalidate-button-path').click();
+
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+
+            await page.reload();
+
+            const val = (await page.getByTestId('data').innerText()).valueOf();
+
+            await page.reload();
+
+            // Page should not have changed after reload if revalidation button was not clicked
+
+            await expect(page.getByTestId('data')).toHaveText(val);
+
+            // wait for text in data-pw="cache-state" to change from "Cache state fresh" to "Cache state stale"
+
+            await expect(page.getByTestId('cache-state')).toContainText('stale', { timeout: 15000 });
+
+            // reload page twice to revalidate
+
+            await page.reload();
+
+            await expect(page.getByTestId('data')).toHaveText(val);
+
+            await page.reload();
+
+            await expect(page.getByTestId('data')).not.toHaveText(val);
+        });
+    }
+});

--- a/apps/cache-testing/tests/pages.spec.ts
+++ b/apps/cache-testing/tests/pages.spec.ts
@@ -1,50 +1,97 @@
 import { test, expect } from '@playwright/test';
 
-const urls = [
-    '/pages/with-paths/fallback-blocking/200',
-    '/pages/with-paths/fallback-true/200',
-    '/pages/with-paths/fallback-false/200',
-    '/pages/no-paths/fallback-blocking/200',
-    '/pages/no-paths/fallback-true/200',
-    // '/pages/no-paths/fallback-false/200', // this fails in native next.js cache
-];
+test.describe('on-demand revalidation', () => {
+    const urls = [
+        '/pages/with-paths/fallback-blocking/200',
+        '/pages/with-paths/fallback-true/200',
+        '/pages/with-paths/fallback-false/200',
+        '/pages/no-paths/fallback-blocking/200',
+        '/pages/no-paths/fallback-true/200',
+        // '/pages/no-paths/fallback-false/200', // this fails in native next.js cache
+    ];
 
-for (const url of urls) {
-    test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
-        await page.goto(url);
+    for (const url of urls) {
+        test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
+            await page.goto(url);
 
-        await page.getByTestId('revalidate-button-path').click();
+            await page.getByTestId('revalidate-button-path').click();
 
-        await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
 
-        await page.reload();
+            await page.reload();
 
-        let val = (await page.getByTestId('data').innerText()).valueOf();
+            let val = (await page.getByTestId('data').innerText()).valueOf();
 
-        await page.reload();
+            await page.reload();
 
-        // Page should not have changed after reload if revalidation button was not clicked
+            // Page should not have changed after reload if revalidation button was not clicked
 
-        await expect(page.getByTestId('data')).toHaveText(val);
+            await expect(page.getByTestId('data')).toHaveText(val);
 
-        // Click on revalidate by path button
+            // Click on revalidate by path button
 
-        await page.getByTestId('revalidate-button-path').click();
+            await page.getByTestId('revalidate-button-path').click();
 
-        await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
 
-        await page.reload();
+            await page.reload();
 
-        // Page should have changed after reload if revalidation button was clicked
+            // Page should have changed after reload if revalidation button was clicked
 
-        await expect(page.getByTestId('data')).not.toHaveText(val);
+            await expect(page.getByTestId('data')).not.toHaveText(val);
 
-        val = (await page.getByTestId('data').innerText()).valueOf();
+            val = (await page.getByTestId('data').innerText()).valueOf();
 
-        await page.reload();
+            await page.reload();
 
-        // Page should not have changed after reload if revalidation button was not clicked
+            // Page should not have changed after reload if revalidation button was not clicked
 
-        await expect(page.getByTestId('data')).toHaveText(val);
-    });
-}
+            await expect(page.getByTestId('data')).toHaveText(val);
+        });
+    }
+});
+
+test.describe('time based revalidation', () => {
+    const urls = [
+        '/pages/with-paths/fallback-blocking/200',
+        '/pages/with-paths/fallback-true/200',
+        '/pages/with-paths/fallback-false/200',
+        '/pages/no-paths/fallback-blocking/200',
+        '/pages/no-paths/fallback-true/200',
+        // '/pages/no-paths/fallback-false/200', // this fails in native next.js cache
+    ];
+
+    for (const url of urls) {
+        test(`testing ${url.split('/').join(' ')}`, async ({ page }) => {
+            await page.goto('/pages/no-paths/fallback-blocking/200');
+
+            await page.getByTestId('revalidate-button-path').click();
+
+            await expect(page.getByTestId('is-revalidated-by-path')).toContainText('Revalidated at');
+
+            await page.reload();
+
+            const val = (await page.getByTestId('data').innerText()).valueOf();
+
+            await page.reload();
+
+            // Page should not have changed after reload if revalidation button was not clicked
+
+            await expect(page.getByTestId('data')).toHaveText(val);
+
+            // wait for text in data-pw="cache-state" to change from "Cache state fresh" to "Cache state stale"
+
+            await expect(page.getByTestId('cache-state')).toContainText('stale', { timeout: 15000 });
+
+            // reload page twice to revalidate
+
+            await page.reload();
+
+            await expect(page.getByTestId('data')).toHaveText(val);
+
+            await page.reload();
+
+            await expect(page.getByTestId('data')).not.toHaveText(val);
+        });
+    }
+});


### PR DESCRIPTION
This commit adds time-based revalidation tests to the project. Tests ensure that `@neshca/cache-handler` works like native Next.js im-memory cache.

In addition, the cache-testing app has been refactored to improve the developer experience (DX). Common code has been moved to a `utils` directory.

Finally, parallel testing has been disabled because of inconsistencies in the time-based revalidation tests. This ensures that the tests run consistently and produce reliable results.