### PR TITLE
Disable disk access to prove a point

### DIFF
--- a/apps/cache-testing/cache-handler-http.js
+++ b/apps/cache-testing/cache-handler-http.js
@@ -66,7 +66,7 @@ IncrementalCache.onCreation(() => {
          * No need to write to disk, as we're using a shared cache.
          * Read is required to get pre-rendering pages from disk
          */
-        diskAccessMode: 'read-yes/write-no',
+        diskAccessMode: 'read-no/write-no',
     };
 });
 


### PR DESCRIPTION
Some basic functionality works differently if the cache doesn't have access to the file system. Please see the falling tests.