### PR TITLE
Fix usage of `cache-handler` in dev env

### DIFF
--- a/.changeset/clean-lamps-hide.md
+++ b/.changeset/clean-lamps-hide.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Fix usage of `cache-handler` in dev environment

--- a/docs/examples/use-with-redis.md
+++ b/docs/examples/use-with-redis.md
@@ -260,3 +260,17 @@ SERVER_STARTED=1 npm run start
 ```
 
 Note that in the `build` step you don't need to set `SERVER_STARTED` environment variable.
+
+## Development environment
+
+When you run `next dev` command, caching in Next.js works differently. It works only for `fetch` cache for App dir pages.
+
+You can identify the development environment by checking the `process.env.NODE_ENV` variable or `onCreation` parameter.
+
+```js
+IncrementalCache.onCreation(({ dev }) => {
+    if (dev) {
+        // ...
+    }
+});
+```

--- a/packages/cache-handler/src/cache-handler.ts
+++ b/packages/cache-handler/src/cache-handler.ts
@@ -164,7 +164,7 @@ export class IncrementalCache implements CacheHandler {
         this.serverDistDir = context.serverDistDir;
         this.experimental = context.experimental;
 
-        if (!context.dev && !IncrementalCache.cache) {
+        if (!IncrementalCache.cache) {
             IncrementalCache.serverDistDir = this.serverDistDir;
             IncrementalCache.init({ dev: context.dev, serverDistDir: this.serverDistDir });
         }


### PR DESCRIPTION
- Remove unnecessary `!context.dev` condition from constructor
- Update doc with `Development environment` paragraph

Fixes: #112 