### PR TITLE
Refactor the functionality of cache layers

### DIFF
--- a/.changeset/chilled-camels-admire.md
+++ b/.changeset/chilled-camels-admire.md
@@ -1,0 +1,16 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Refactored the functionality of cache layers
+
+#### Features
+
+-   removed `unstable__logErrors` option
+-   introduced `name` property for Handlers for easier debugging
+-   introduced explicit cache debug logs using `process.env.NEXT_PRIVATE_DEBUG_CACHE`
+-   added a new `timeoutMs` option to the Redis Handlers
+
+#### Fixes
+
+-   Made pre-configured Redis Handler not cause page loading to hang

--- a/.changeset/sweet-worms-fry.md
+++ b/.changeset/sweet-worms-fry.md
@@ -1,0 +1,11 @@
+---
+'cache-handler-docs': patch
+---
+
+Updated the docs.
+
+#### What's Changed
+
+-   Added information about the `timeoutMs` option for Redis Handlers.
+-   Added information about the `name` property for `cache` objects.
+-   Improved the debugging section.

--- a/apps/cache-testing/cache-handler-redis-stack.js
+++ b/apps/cache-testing/cache-handler-redis-stack.js
@@ -8,7 +8,7 @@ if (!process.env.REDIS_URL) {
     console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
 }
 
-const CONNECT_TIMEOUT_MS = 5 * 50 * 1000;
+const CONNECT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 const client = createClient({
     url: process.env.REDIS_URL,
@@ -18,8 +18,8 @@ const client = createClient({
     },
 });
 
-client.on('error', (error) => {
-    console.error('Redis error:', error);
+client.on('error', (_error) => {
+    // console.error('Redis error:', error);
 });
 
 IncrementalCache.onCreation(async () => {

--- a/apps/cache-testing/cache-handler-redis-strings.js
+++ b/apps/cache-testing/cache-handler-redis-strings.js
@@ -8,7 +8,7 @@ if (!process.env.REDIS_URL) {
 }
 
 const PREFIX = 'string:';
-const CONNECT_TIMEOUT_MS = 5 * 50 * 1000;
+const CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
 
 const client = createClient({
     url: process.env.REDIS_URL,

--- a/docs/cache-handler-docs/src/pages/configuration/cache.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/cache.mdx
@@ -13,6 +13,7 @@ IncrementalCache.onCreation(async () => {
     const cacheStore = new Map();
 
     const cache = {
+        name: 'custom-map-cache',
         async get(key) {
             return cacheStore.get(key);
         },
@@ -30,6 +31,12 @@ IncrementalCache.onCreation(async () => {
 module.exports = IncrementalCache;
 ```
 
+<Callout type="info">
+    Don't suppress errors when implementing the `get`, `set`, `getRevalidatedTags`, and `revalidateTag` methods.
+    Instead, throw errors and let `IncrementalCache` class handle them. Refer to the [debugging cache
+    article](/troubleshooting#method-2-debug-mode) for more information.
+</Callout>
+
 ## Advanced Cache Configuration: Custom Revalidation
 
 When you are using built-in Handlers like [`redis-stack`](/redis-stack) there is no need in configuring revalidation. However, if you crafting your own cache handler, you need to implement revalidation logic.
@@ -42,6 +49,7 @@ For control over the revalidation process, implement `getRevalidatedTags` and `r
 const revalidateTags = {};
 
 const cache = {
+    name: 'custom-map-cache',
     async get(key) {
         return cacheStore.get(key);
     },

--- a/docs/cache-handler-docs/src/pages/configuration/on-creation.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/on-creation.mdx
@@ -122,6 +122,11 @@ In these examples, the `onCreation` hook configures the cache behavior based on 
     - The method returns the `RevalidatedTags` from the first cache layer where they are found.
 
 4. **`revalidateTag(tag, revalidatedAt)`: Updating Revalidation Status Across Layers**
+
     - Similar to the `set` method, `revalidateTag` concurrently updates the revalidation status of a tag in all cache layers.
     - It marks the specified `tag` as revalidated with the provided timestamp (`revalidatedAt`) in both the `primaryCache` and `secondaryCache`.
     - It uses `Promise.allSettled` under the hood, ensuring that the revalidation status is consistently updated across all layers.
+
+5. **`name`: A descriptive name for the cache handler instance.**
+
+    - This is used for logging and debugging purposes.

--- a/docs/cache-handler-docs/src/pages/configuration/ttl.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/ttl.mdx
@@ -54,12 +54,8 @@ IncrementalCache.onCreation(async () => {
         // ... other cache methods ...
 
         async set(key, value, ttl) {
-            try {
-                // Serialize value and set TTL using Redis 'EX' option
-                await client.set(key, JSON.stringify(value), typeof ttl === 'number' ? { EX: ttl } : undefined);
-            } catch (error) {
-                console.error('cache.set', error);
-            }
+            // Serialize value and set TTL using Redis 'EX' option
+            await client.set(key, JSON.stringify(value), typeof ttl === 'number' ? { EX: ttl } : undefined);
         },
 
         // ... other cache methods ...
@@ -81,15 +77,11 @@ IncrementalCache.onCreation(async () => {
         // ... other cache methods ...
 
         async set(key, value, ttl) {
-            try {
-                await client.json.set(key, '.', value);
+            await client.json.set(key, '.', value);
 
-                if (typeof ttl === 'number') {
-                    // Set TTL using Redis 'EXPIRE' command
-                    await client.expire(key, ttl);
-                }
-            } catch (error) {
-                console.error('cache.set', error);
+            if (typeof ttl === 'number') {
+                // Set TTL using Redis 'EXPIRE' command
+                await client.expire(key, ttl);
             }
         },
 

--- a/docs/cache-handler-docs/src/pages/configuration/use-file-system.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/use-file-system.mdx
@@ -73,7 +73,6 @@ IncrementalCache.onCreation(async (context) => {
     const lruCache = createLruCache({
         maxItemsNumber: 10000, // Limit to 10000 items
         maxItemSizeBytes: 1024 * 1024 * 500, // Limit to 500 MB
-        unstable__logErrors: true,
     });
 
     return {

--- a/docs/cache-handler-docs/src/pages/redis-stack-custom.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-stack-custom.mdx
@@ -11,6 +11,7 @@ Create a file called `cache-handler.js` next to you `next.config.js` with the fo
 
 ```js filename="cache-handler.js" copy
 const { IncrementalCache } = require('@neshca/cache-handler');
+const createLruCache = require('@neshca/cache-handler/local-lru').default;
 const { createClient } = require('redis');
 
 const REVALIDATED_TAGS_KEY = 'sharedRevalidatedTags';
@@ -24,12 +25,19 @@ client.on('error', (error) => {
 });
 
 IncrementalCache.onCreation(async () => {
+    await client.connect();
+
     // read more about TTL limitations https://caching-tools.github.io/next-shared-cache/configuration/ttl
     const useTtl = false;
 
-    await client.connect();
+    function assertClientIsReady() {
+        if (!client.isReady) {
+            throw new Error('Redis client is not ready');
+        }
+    }
 
-    // Create the shared RevalidatedTags if it doesn't exist
+    assertClientIsReady();
+
     await client.json.set(
         REVALIDATED_TAGS_KEY,
         '.',
@@ -39,52 +47,56 @@ IncrementalCache.onCreation(async () => {
         },
     );
 
-    return {
-        useFileSystem: !useTtl,
-        cache: {
-            async get(key) {
-                try {
-                    const cacheValue = (await client.json.get(key)) ?? null;
+    const localCache = createLruCache({
+        useTtl,
+    });
 
-                    if (cacheValue && cacheValue.value?.kind === 'ROUTE' && cacheValue.value.body.type === 'Buffer') {
-                        cacheValue.value.body = Buffer.from(cacheValue.value.body);
-                    }
+    const redisCache = {
+        name: 'custom-redis-stack',
+        async get(key) {
+            assertClientIsReady();
 
-                    return cacheValue;
-                } catch (error) {
-                    console.error('cache.get', error);
+            const cacheValue = (await client.json.get(key)) ?? null;
 
-                    return null;
-                }
-            },
-            async set(key, value, ttl) {
-                try {
-                    await client.json.set(key, '.', value);
+            if (cacheValue?.value?.kind === 'ROUTE') {
+                cacheValue.value.body = Buffer.from(cacheValue.value.body, 'base64');
+            }
 
-                    if (useTtl && typeof ttl === 'number') {
-                        await client.expire(key, ttl);
-                    }
-                } catch (error) {
-                    console.error('cache.set', error);
-                }
-            },
-            async getRevalidatedTags() {
-                try {
-                    const sharedRevalidatedTags = (await client.json.get(REVALIDATED_TAGS_KEY)) ?? undefined;
-
-                    return sharedRevalidatedTags;
-                } catch (error) {
-                    console.error('cache.getRevalidatedTags', error);
-                }
-            },
-            async revalidateTag(tag, revalidatedAt) {
-                try {
-                    await client.json.set(REVALIDATED_TAGS_KEY, `.${tag}`, revalidatedAt);
-                } catch (error) {
-                    console.error('cache.revalidateTag', error);
-                }
-            },
+            return cacheValue;
         },
+        async set(key, cacheValue, ttl) {
+            assertClientIsReady();
+
+            let preparedCacheValue = cacheValue;
+
+            if (cacheValue.value?.kind === 'ROUTE') {
+                preparedCacheValue = structuredClone(cacheValue);
+                preparedCacheValue.value.body = cacheValue.value.body.toString('base64');
+            }
+
+            await client.json.set(key, '.', preparedCacheValue);
+
+            if (useTtl && typeof ttl === 'number') {
+                await client.expire(key, ttl);
+            }
+        },
+        async getRevalidatedTags() {
+            assertClientIsReady();
+
+            const sharedRevalidatedTags = (await client.json.get(REVALIDATED_TAGS_KEY)) ?? undefined;
+
+            return sharedRevalidatedTags;
+        },
+        async revalidateTag(tag, revalidatedAt) {
+            assertClientIsReady();
+
+            await client.json.set(REVALIDATED_TAGS_KEY, `.${tag}`, revalidatedAt);
+        },
+    };
+
+    return {
+        cache: [redisCache, localCache],
+        useFileSystem: !useTtl,
     };
 });
 

--- a/docs/cache-handler-docs/src/pages/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-stack.mdx
@@ -32,6 +32,9 @@ IncrementalCache.onCreation(async () => {
     const redisCache = await createRedisCache({
         client,
         useTtl,
+        // timeout for the Redis client operations like `get` and `set`
+        // afeter this timeout, the operation will be considered failed and the `localCache` will be used
+        timeoutMs: 5000,
     });
 
     const localCache = createLruCache({

--- a/docs/cache-handler-docs/src/pages/redis-strings-custom.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-strings-custom.mdx
@@ -16,8 +16,9 @@ npm i -D @neshca/json-replacer-reviver
 Create a file called `cache-handler.js` next to your `next.config.js` with the following contents:
 
 ```js filename="cache-handler.js" copy
-const { reviveFromBase64Representation, replaceJsonWithBase64 } = require('@neshca/json-replacer-reviver');
 const { IncrementalCache } = require('@neshca/cache-handler');
+const createLruCache = require('@neshca/cache-handler/local-lru').default;
+const { reviveFromBase64Representation, replaceJsonWithBase64 } = require('@neshca/json-replacer-reviver');
 const { createClient } = require('redis');
 
 const REVALIDATED_TAGS_KEY = 'sharedRevalidatedTags';
@@ -36,62 +37,63 @@ IncrementalCache.onCreation(async () => {
 
     await client.connect();
 
-    return {
-        useFileSystem: !useTtl,
-        cache: {
-            async get(key) {
-                try {
-                    const result = (await client.get(key)) ?? null;
+    const localCache = createLruCache({
+        useTtl,
+    });
 
-                    if (!result) {
-                        return null;
-                    }
+    function assertClientIsReady() {
+        if (!client.isReady) {
+            throw new Error('Redis client is not ready');
+        }
+    }
+    const redisCache = {
+        name: 'custom-redis-strings',
+        async get(key) {
+            assertClientIsReady();
 
-                    // use reviveFromBase64Representation to restore binary data from Base64
-                    return JSON.parse(result, reviveFromBase64Representation);
-                } catch (error) {
-                    console.error('cache.get', error);
+            const result = await client.get(key);
 
-                    return null;
-                }
-            },
-            async set(key, value, ttl) {
-                try {
-                    await client.set(
-                        key,
-                        // use replaceJsonWithBase64 to store binary data in Base64 and save space
-                        JSON.stringify(value, replaceJsonWithBase64),
-                        useTtl && typeof ttl === 'number' ? { EX: ttl } : undefined,
-                    );
-                } catch (error) {
-                    console.error('cache.set', error);
-                }
-            },
-            async getRevalidatedTags() {
-                try {
-                    const sharedRevalidatedTags = await client.hGetAll(REVALIDATED_TAGS_KEY);
+            if (!result) {
+                return null;
+            }
 
-                    const entries = Object.entries(sharedRevalidatedTags);
-
-                    const revalidatedTags = Object.fromEntries(
-                        entries.map(([tag, revalidatedAt]) => [tag, Number(revalidatedAt)]),
-                    );
-
-                    return revalidatedTags;
-                } catch (error) {
-                    console.error('cache.getRevalidatedTags', error);
-                }
-            },
-            async revalidateTag(tag, revalidatedAt) {
-                try {
-                    await client.hSet(REVALIDATED_TAGS_KEY, {
-                        [tag]: revalidatedAt,
-                    });
-                } catch (error) {
-                    console.error('cache.revalidateTag', error);
-                }
-            },
+            return JSON.parse(result, reviveFromBase64Representation);
         },
+        async set(key, value, ttl) {
+            assertClientIsReady();
+
+            await client.set(
+                key,
+                JSON.stringify(value, replaceJsonWithBase64),
+                useTtl && typeof ttl === 'number' ? { EX: ttl } : undefined,
+            );
+        },
+        async getRevalidatedTags() {
+            assertClientIsReady();
+
+            const sharedRevalidatedTags = await client.hGetAll(REVALIDATED_TAGS_KEY);
+
+            const entries = Object.entries(sharedRevalidatedTags);
+
+            const revalidatedTags = entries.reduce((acc, [tag, revalidatedAt]) => {
+                acc[tag] = Number(revalidatedAt);
+                return acc;
+            }, {});
+
+            return revalidatedTags;
+        },
+        async revalidateTag(tag, revalidatedAt) {
+            assertClientIsReady();
+
+            await client.hSet(REVALIDATED_TAGS_KEY, {
+                [tag]: revalidatedAt,
+            });
+        },
+    };
+
+    return {
+        cache: [redisCache, localCache],
+        useFileSystem: !useTtl,
     };
 });
 

--- a/docs/cache-handler-docs/src/pages/redis-strings.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-strings.mdx
@@ -32,6 +32,9 @@ IncrementalCache.onCreation(async () => {
     const redisCache = await createRedisCache({
         client,
         useTtl,
+        // timeout for the Redis client operations like `get` and `set`
+        // afeter this timeout, the operation will be considered failed and the `localCache` will be used
+        timeoutMs: 5000,
     });
 
     const localCache = createLruCache({

--- a/docs/cache-handler-docs/src/pages/troubleshooting.mdx
+++ b/docs/cache-handler-docs/src/pages/troubleshooting.mdx
@@ -56,7 +56,8 @@ Verbose output should appear in your console when the application starts and any
 
 ```
 using custom cache handler @neshca/cache-handler with 1 Handlers and file system caching
-using custom cache handler @neshca/cache-handler with 1 Handlers and file system caching
+get from "redis-stack" ba7bea0a3991dc2cbf8e068da71c2a2aa8c0e6f902fe695c1badf1e994acc43a false
+set to external cache store 8f058e8d96c4010b07abddd0f9f26ebd9ed71e2ccfb18eca348fc57a6e86f986
 ```
 
 Note: During the build stage, it's normal to see `@neshca/cache-handler is not configured yet` several times.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,15 @@
                 "typescript": "5.3.3"
             }
         },
+        "apps/cache-testing/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "apps/cache-testing/node_modules/next": {
             "version": "14.0.5-canary.17",
             "resolved": "https://registry.npmjs.org/next/-/next-14.0.5-canary.17.tgz",
@@ -131,6 +140,15 @@
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
+            }
+        },
+        "docs/cache-handler-docs/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "docs/cache-handler-docs/node_modules/glob": {
@@ -251,6 +269,15 @@
                 "typescript": "5.3.3"
             }
         },
+        "internal/backend/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "internal/eslint-config-neshca": {
             "version": "0.0.0",
             "license": "MIT",
@@ -357,6 +384,15 @@
                 "typescript": "5.3.3"
             }
         },
+        "internal/next-common/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "internal/next-common/node_modules/next": {
             "version": "14.0.5-canary.17",
             "resolved": "https://registry.npmjs.org/next/-/next-14.0.5-canary.17.tgz",
@@ -417,6 +453,15 @@
                 "eslint-config-neshca": "*",
                 "rimraf": "5.0.5",
                 "typescript": "5.3.3"
+            }
+        },
+        "internal/next-lru-cache/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "internal/prettier-config": {
@@ -1825,11 +1870,6 @@
                 "fs-extra": "^8.1.0"
             }
         },
-        "node_modules/@manypkg/find-root/node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-        },
         "node_modules/@manypkg/find-root/node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -3105,12 +3145,9 @@
             "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
         },
         "node_modules/@types/node": {
-            "version": "20.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
-            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
-            "dependencies": {
-                "undici-types": "~5.26.4"
-            }
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
         },
         "node_modules/@types/node-fetch": {
             "version": "2.6.9",
@@ -3167,16 +3204,16 @@
             "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
-            "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+            "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/type-utils": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/type-utils": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -3202,15 +3239,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
-            "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+            "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3230,13 +3267,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-            "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+            "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0"
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -3247,13 +3284,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
-            "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+            "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.14.0",
-                "@typescript-eslint/utils": "6.14.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
+                "@typescript-eslint/utils": "6.15.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -3274,9 +3311,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-            "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+            "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -3287,13 +3324,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-            "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+            "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/visitor-keys": "6.14.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/visitor-keys": "6.15.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -3314,17 +3351,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
-            "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+            "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.14.0",
-                "@typescript-eslint/types": "6.14.0",
-                "@typescript-eslint/typescript-estree": "6.14.0",
+                "@typescript-eslint/scope-manager": "6.15.0",
+                "@typescript-eslint/types": "6.15.0",
+                "@typescript-eslint/typescript-estree": "6.15.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -3339,12 +3376,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-            "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+            "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.14.0",
+                "@typescript-eslint/types": "6.15.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -5659,9 +5696,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.614",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz",
-            "integrity": "sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ==",
+            "version": "1.4.615",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
+            "integrity": "sha512-/bKPPcgZVUziECqDc+0HkT87+0zhaWSZHNXqF8FLd2lQcptpmUFwoCSWjCdOng9Gdq+afKArPdEg/0ZW461Eng==",
             "dev": true
         },
         "node_modules/elkjs": {
@@ -7310,9 +7347,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+            "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -11680,9 +11717,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-4.23.0.tgz",
-            "integrity": "sha512-ey2CXh1OTcTUa0AWZWuTpgA9t5GuAG3DVU1MofCRUI7fQJij8XJ3Sr0VtgxoAE69C9wbHBMCux8Z/IQZfSwHiA==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-4.24.0.tgz",
+            "integrity": "sha512-h8fsas4lu0ul18oDzFIZpEQryh2SJEUJWanyfEwjME/klcKWZM/blDz2cKiT+aFBqPJzcYdCUj/8E7n20f0jEw==",
             "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
@@ -12795,9 +12832,9 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.0.tgz",
-            "integrity": "sha512-AeYh93VyUwnNI/HCB4XdAaP4N/yGgg3rci3ISEUSM0jN95yWpbL9tSuRIwHzCq7e6TzYwJ6Vn7viUYTsfIxBlQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.1.tgz",
+            "integrity": "sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -16372,11 +16409,21 @@
                 "eslint-config-neshca": "*",
                 "rimraf": "5.0.5",
                 "tsup": "8.0.1",
+                "tsx": "4.7.0",
                 "typescript": "5.3.3"
             },
             "peerDependencies": {
                 "next": ">=13.5.1",
                 "redis": ">=4.6"
+            }
+        },
+        "packages/cache-handler/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "packages/diffscribe": {
@@ -16398,6 +16445,15 @@
                 "openai": "^4.12.3"
             }
         },
+        "packages/diffscribe/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "packages/json-replacer-reviver": {
             "name": "@neshca/json-replacer-reviver",
             "version": "1.1.0",
@@ -16410,6 +16466,15 @@
                 "tsup": "8.0.1",
                 "tsx": "4.7.0",
                 "typescript": "5.3.3"
+            }
+        },
+        "packages/json-replacer-reviver/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "packages/server": {
@@ -16433,6 +16498,15 @@
                 "tsup": "8.0.1",
                 "tsx": "4.7.0",
                 "typescript": "5.3.3"
+            }
+        },
+        "packages/server/node_modules/@types/node": {
+            "version": "20.10.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+            "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         }
     }

--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -49,7 +49,9 @@
         "build": "tsup --dts-resolve",
         "clean": "rimraf ./dist ./.turbo ./node_modules",
         "dev": "tsup --watch",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "test": "node --test --import tsx/esm **/*.test.ts",
+        "test:watch": "node --watch --test --import tsx/esm **/*.test.ts"
     },
     "dependencies": {
         "@neshca/json-replacer-reviver": "*",
@@ -63,6 +65,7 @@
         "eslint-config-neshca": "*",
         "rimraf": "5.0.5",
         "tsup": "8.0.1",
+        "tsx": "4.7.0",
         "typescript": "5.3.3"
     },
     "peerDependencies": {

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -1,10 +1,3 @@
 import type { RedisClientType } from 'redis';
 
 export type RedisJSON = Parameters<RedisClientType['json']['set']>['2'];
-
-export type CacheHandlerOptions = {
-    /**
-     * Optional. If set to true, logs errors to the console. Defaults to false.
-     */
-    unstable__logErrors?: boolean;
-};

--- a/packages/cache-handler/src/handlers/local-lru.ts
+++ b/packages/cache-handler/src/handlers/local-lru.ts
@@ -1,18 +1,14 @@
 /* eslint-disable import/no-default-export -- use default here */
-/* eslint-disable camelcase -- unstable__* */
-/* eslint-disable no-console -- log errors */
 import type { LruCacheOptions } from '@neshca/next-lru-cache/next-cache-handler-value';
 import { createCache } from '@neshca/next-lru-cache/next-cache-handler-value';
 import type { Cache } from '../cache-handler';
-import type { CacheHandlerOptions } from '../common-types';
 
-export type LruCacheHandlerOptions = CacheHandlerOptions &
-    LruCacheOptions & {
-        /**
-         * Optional. Enables ttl support. Defaults to `false`.
-         */
-        useTtl?: boolean;
-    };
+export type LruCacheHandlerOptions = LruCacheOptions & {
+    /**
+     * Optional. Enables ttl support. Defaults to `false`.
+     */
+    useTtl?: boolean;
+};
 
 /**
  * Creates an LRU (Least Recently Used) cache handler.
@@ -31,40 +27,22 @@ export type LruCacheHandlerOptions = CacheHandlerOptions &
  * const lruCache = createLruCache({
  *   maxItemsNumber: 10000, // 10000 items
  *   maxItemSizeBytes: 1024 * 1024 * 500, // 500 MB
- *   unstable__logErrors: true
  * });
  * ```
  *
  * @remarks
  * Use this Handler as a fallback for Redis Handler instead of the filesystem when you use only the App router.
  */
-export default function createLruCache({
-    unstable__logErrors,
-    useTtl,
-    ...lruOptions
-}: LruCacheHandlerOptions = {}): Cache {
+export default function createLruCache({ useTtl, ...lruOptions }: LruCacheHandlerOptions = {}): Cache {
     const lruCache = createCache(lruOptions);
 
     return {
+        name: 'local-lru',
         get(key) {
-            try {
-                return Promise.resolve(lruCache.get(key));
-            } catch (error) {
-                if (unstable__logErrors) {
-                    console.error('cache.get', error);
-                }
-
-                return Promise.resolve(null);
-            }
+            return Promise.resolve(lruCache.get(key));
         },
         set(key, value, ttl = 0) {
-            try {
-                lruCache.set(key, value, useTtl ? { ttl: ttl * 1000 } : undefined);
-            } catch (error) {
-                if (unstable__logErrors) {
-                    console.error('cache.set', error);
-                }
-            }
+            lruCache.set(key, value, useTtl ? { ttl: ttl * 1000 } : undefined);
 
             return Promise.resolve();
         },

--- a/packages/cache-handler/src/is-tags-manifest.ts
+++ b/packages/cache-handler/src/is-tags-manifest.ts
@@ -1,10 +1,10 @@
 import type { TagsManifest } from '@neshca/next-common';
 
-function hasItems(object: object): object is { items: object } {
+function hasItems(object: object): object is { items: unknown } {
     return Object.hasOwn(object, 'items');
 }
 
-function hasVersion(object: object): object is { version: number } {
+function hasVersion(object: object): object is { version: unknown } {
     return Object.hasOwn(object, 'version');
 }
 
@@ -13,9 +13,8 @@ export function isTagsManifest(object: unknown): object is TagsManifest {
         typeof object === 'object' &&
         object !== null &&
         hasItems(object) &&
-        typeof object.items === 'object' &&
-        object.items !== null &&
         hasVersion(object) &&
+        typeof object.version === 'number' &&
         object.version === 1
     );
 }

--- a/packages/cache-handler/src/with-timeout.test.ts
+++ b/packages/cache-handler/src/with-timeout.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { withTimeout } from './with-timeout';
+
+function simulateOperation(duration: number): Promise<string> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, duration, 'completed');
+    });
+}
+
+await test('should resolve if operation finishes before timeout', async () => {
+    const fastOperation = simulateOperation(100);
+    const result = await withTimeout(fastOperation, 200);
+    assert.strictEqual(result, 'completed');
+});
+
+await test('should reject if operation times out', async () => {
+    const slowOperation = simulateOperation(300);
+    try {
+        await withTimeout(slowOperation, 100);
+        assert.fail('Expected operation to time out');
+    } catch (error) {
+        if (error instanceof Error) {
+            assert.match(error.message, /timed out/);
+        }
+    }
+});
+
+await test('should allow operation without timeout when timeoutMs is undefined', async () => {
+    const operation = simulateOperation(100);
+    const result = await withTimeout(operation);
+    assert.strictEqual(result, 'completed');
+});

--- a/packages/cache-handler/src/with-timeout.ts
+++ b/packages/cache-handler/src/with-timeout.ts
@@ -1,0 +1,19 @@
+export function withTimeout<T>(operation: Promise<T>, timeoutMs?: number): Promise<T> {
+    if (typeof timeoutMs !== 'number' || isNaN(timeoutMs) || timeoutMs <= 0) {
+        return operation;
+    }
+
+    return new Promise((resolve, reject) => {
+        const timeoutHandle = setTimeout(reject, timeoutMs, new Error(`Operation timed out after ${timeoutMs} ms`));
+
+        operation
+            .then((result) => {
+                clearTimeout(timeoutHandle);
+                resolve(result);
+            })
+            .catch((error) => {
+                clearTimeout(timeoutHandle);
+                reject(error);
+            });
+    });
+}


### PR DESCRIPTION
This pull request refactors the functionality of cache layers.

- centrolized error handling the layers
- explicit debug logs with `NEXT_PRIVATE_DEBUG_CACHE` environment variable
- `timeoutMs` option to `redis-stack` and `redis-strings` Handlers
- named Handlers

Fix #230 