### PR TITLE
Refactor Redis Handlers timeout handling

### DIFF
--- a/.changeset/hip-taxis-listen.md
+++ b/.changeset/hip-taxis-listen.md
@@ -1,0 +1,10 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Refactored Redis Handlers timeout handling
+
+#### Changes
+
+-   Refactored Redis Handlers to use `AbortSignal` instead of promisifying `setTimeout`.
+-   Set default Redis Handlers `timeoutMs` option to 5000 ms.

--- a/apps/cache-testing/cache-handler-redis-stack.js
+++ b/apps/cache-testing/cache-handler-redis-stack.js
@@ -8,14 +8,9 @@ if (!process.env.REDIS_URL) {
     console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
 }
 
-const CONNECT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
 const client = createClient({
     url: process.env.REDIS_URL,
     name: `cache-handler:${process.env.PORT ?? process.pid}`,
-    socket: {
-        connectTimeout: CONNECT_TIMEOUT_MS,
-    },
 });
 
 client.on('error', (error) => {
@@ -30,9 +25,10 @@ IncrementalCache.onCreation(async () => {
     const redisCache = await createRedisCache({
         client,
         keyPrefix: 'JSON:',
+        timeoutMs: 1000,
     });
 
-    const redisStringsCache = createRedisStringsCache({ client, keyPrefix: 'strings:' });
+    const redisStringsCache = createRedisStringsCache({ client, keyPrefix: 'strings:', timeoutMs: 1000 });
 
     const localCache = createLruCache();
 

--- a/apps/cache-testing/cache-handler-redis-strings.js
+++ b/apps/cache-testing/cache-handler-redis-strings.js
@@ -8,14 +8,10 @@ if (!process.env.REDIS_URL) {
 }
 
 const PREFIX = 'string:';
-const CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
 
 const client = createClient({
     url: process.env.REDIS_URL,
     name: `cache-handler:${PREFIX}${process.env.PORT ?? process.pid}`,
-    socket: {
-        connectTimeout: CONNECT_TIMEOUT_MS,
-    },
 });
 
 client.on('error', (error) => {
@@ -23,9 +19,11 @@ client.on('error', (error) => {
 });
 
 IncrementalCache.onCreation(async () => {
+    console.log('Connecting Redis client...');
     await client.connect();
+    console.log('Redis client connected.');
 
-    const redisCache = await createRedisCache({
+    const redisCache = createRedisCache({
         client,
         keyPrefix: PREFIX,
     });

--- a/docs/cache-handler-docs/theme.config.jsx
+++ b/docs/cache-handler-docs/theme.config.jsx
@@ -53,7 +53,7 @@ export default {
         key: '0.6.0-release',
         text: (
             <a href={`${process.env.NEXT_PUBLIC_BASE_URL}`}>
-                🎉 Version 0.6.4 is out, offering stale-while-revalidate strategy emulation!
+                🎉 Version 0.6.5 is out, offering stale-while-revalidate strategy emulation and codebase improvements!
             </a>
         ),
     },

--- a/docs/contributing/cache-handler.md
+++ b/docs/contributing/cache-handler.md
@@ -50,7 +50,7 @@ npm run e2e:ui -w @neshca/cache-testing
 **Important**: Clear the Redis DB before executing tests:
 
 ```bash
-docker exec -it redis-stack redis-cli
+docker exec -it cache-handler-redis redis-cli
 127.0.0.1:6379> flushall
 OK
 ```

--- a/packages/cache-handler/README.md
+++ b/packages/cache-handler/README.md
@@ -2,7 +2,7 @@
 
 **Flexible API to replace the default Next.js cache, accommodating custom cache solutions for multi-instance self-hosted deployments**
 
-🎉 Version 0.6.4 is out, offering stale-while-revalidate strategy emulation!
+🎉 Version 0.6.5 is out, offering stale-while-revalidate strategy emulation and codebase improvements!
 
 Check out the [changelog](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/CHANGELOG.md)
 

--- a/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
+++ b/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
@@ -1,0 +1,7 @@
+import { commandOptions } from 'redis';
+
+type CommandOptions = ReturnType<typeof commandOptions>;
+
+export function getTimeoutRedisCommandOptions(timeoutMs: number): CommandOptions {
+    return commandOptions({ signal: AbortSignal.timeout(timeoutMs) });
+}


### PR DESCRIPTION
This pull request refactors the Redis Handlers timeout handling by using `AbortSignal` instead of promisifying `setTimeout`. It also sets the default Redis Handlers `timeoutMs` option to 5000 ms.