### PR TITLE
Update Next.js dependencies and cacheHandler configuration

### DIFF
--- a/.changeset/eight-melons-judge.md
+++ b/.changeset/eight-melons-judge.md
@@ -1,0 +1,5 @@
+---
+'cache-handler-docs': patch
+---
+
+Updated installation documentation section with stabilized `cacheHandler` Next Config option.

--- a/apps/cache-testing/next.config.js
+++ b/apps/cache-testing/next.config.js
@@ -1,14 +1,15 @@
 const path = require('node:path');
 
-const incrementalCacheHandlerPath = require.resolve(process.env.HANDLER_PATH ?? './cache-handler-redis-stack');
+const cacheHandler = require.resolve(process.env.HANDLER_PATH ?? './cache-handler-redis-stack');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     poweredByHeader: false,
     reactStrictMode: true,
     output: 'standalone',
+    cacheHandler: process.env.NODE_ENV !== 'development' ? cacheHandler : undefined,
+    cacheMaxMemorySize: 0, // disable default in-memory caching
     experimental: {
-        incrementalCacheHandlerPath: process.env.NODE_ENV !== 'development' ? incrementalCacheHandlerPath : undefined,
         // PPR should only be configured via the PPR_ENABLED env variable due to conditional logic in tests.
         ppr: process.env.PPR_ENABLED === 'true',
         largePageDataBytes: 1024 * 1024, // 1MB

--- a/apps/cache-testing/package.json
+++ b/apps/cache-testing/package.json
@@ -16,7 +16,7 @@
         "start": "dotenv -e .env.local -v SERVER_STARTED=1 node .next/standalone/apps/cache-testing/server.js"
     },
     "dependencies": {
-        "next": "14.0.5-canary.58",
+        "next": "14.1.1-canary.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
     },
@@ -24,7 +24,7 @@
         "@neshca/cache-handler": "*",
         "@neshca/json-replacer-reviver": "*",
         "@neshca/tsconfig": "*",
-        "@next/eslint-plugin-next": "14.0.5-canary.58",
+        "@next/eslint-plugin-next": "14.1.1-canary.1",
         "@playwright/test": "1.41.0",
         "@types/node": "20.11.5",
         "@types/react": "18.2.48",

--- a/docs/cache-handler-docs/package.json
+++ b/docs/cache-handler-docs/package.json
@@ -10,7 +10,7 @@
         "start:docs": "next start"
     },
     "dependencies": {
-        "next": "14.0.4",
+        "next": "14.1.0",
         "nextra": "2.13.2",
         "nextra-theme-docs": "2.13.2",
         "react": "18.2.0",
@@ -18,7 +18,7 @@
     },
     "devDependencies": {
         "@neshca/tsconfig": "*",
-        "@next/eslint-plugin-next": "14.0.4",
+        "@next/eslint-plugin-next": "14.1.0",
         "@types/node": "20.11.5",
         "@types/react": "18.2.48",
         "@types/react-dom": "18.2.18",

--- a/docs/cache-handler-docs/src/pages/configuration/development-environment.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/development-environment.mdx
@@ -6,11 +6,11 @@ The easiest way to turn off the cache handler in a development environment is to
 
 ```js filename="next.config.js" copy
 const nextConfig = {
-    /* ... */
-    experimental: {
-        incrementalCacheHandlerPath:
-            process.env.NODE_ENV === 'development' ? undefined : require.resolve('./cache-handler'),
-    },
-    /* ... */
+    cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler') : undefined,
+    // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
+    /* experimental: {
+            incrementalCacheHandlerPath:
+                process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler') : undefined,
+    }, */
 };
 ```

--- a/docs/cache-handler-docs/src/pages/installation.mdx
+++ b/docs/cache-handler-docs/src/pages/installation.mdx
@@ -78,10 +78,12 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
 
     ```js filename="next.config.js" copy
     const nextConfig = {
-        experimental: {
+        cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler') : undefined,
+        // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
+        /* experimental: {
             incrementalCacheHandlerPath:
                 process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler') : undefined,
-        },
+        }, */
     };
 
     module.exports = nextConfig;

--- a/internal/next-common/package.json
+++ b/internal/next-common/package.json
@@ -13,7 +13,7 @@
         "lint:fix": "eslint --fix ."
     },
     "dependencies": {
-        "next": "14.0.5-canary.58"
+        "next": "14.1.1-canary.1"
     },
     "devDependencies": {
         "@neshca/tsconfig": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "next": "14.0.5-canary.58",
+                "next": "14.1.1-canary.1",
                 "react": "18.2.0",
                 "react-dom": "18.2.0"
             },
@@ -44,7 +44,7 @@
                 "@neshca/cache-handler": "*",
                 "@neshca/json-replacer-reviver": "*",
                 "@neshca/tsconfig": "*",
-                "@next/eslint-plugin-next": "14.0.5-canary.58",
+                "@next/eslint-plugin-next": "14.1.1-canary.1",
                 "@playwright/test": "1.41.0",
                 "@types/node": "20.11.5",
                 "@types/react": "18.2.48",
@@ -59,15 +59,24 @@
                 "typescript": "5.3.3"
             }
         },
-        "apps/cache-testing/node_modules/next": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.0.5-canary.58.tgz",
-            "integrity": "sha512-xZjkkbIDHCnzlV2M//0ehB72Wcxkw0yYsKqDr6+8VX9/BqBx8Z7mP/8d2ezF+c3lVcje6UODsmZW29IXpc5wKQ==",
+        "apps/cache-testing/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
             "dependencies": {
-                "@next/env": "14.0.5-canary.58",
+                "undici-types": "~5.26.4"
+            }
+        },
+        "apps/cache-testing/node_modules/next": {
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.1.1-canary.1.tgz",
+            "integrity": "sha512-17sG8plUzgT9xjdac11qFQUcF2JAgJ8h59U8ME1Ykaboy8sk7IkkD+HuOCJxREzsLtDh6Q8gqWxEAt+j9VuS/Q==",
+            "dependencies": {
+                "@next/env": "14.1.1-canary.1",
                 "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
-                "caniuse-lite": "^1.0.30001406",
+                "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",
                 "postcss": "8.4.31",
                 "styled-jsx": "5.1.1"
@@ -79,15 +88,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.0.5-canary.58",
-                "@next/swc-darwin-x64": "14.0.5-canary.58",
-                "@next/swc-linux-arm64-gnu": "14.0.5-canary.58",
-                "@next/swc-linux-arm64-musl": "14.0.5-canary.58",
-                "@next/swc-linux-x64-gnu": "14.0.5-canary.58",
-                "@next/swc-linux-x64-musl": "14.0.5-canary.58",
-                "@next/swc-win32-arm64-msvc": "14.0.5-canary.58",
-                "@next/swc-win32-ia32-msvc": "14.0.5-canary.58",
-                "@next/swc-win32-x64-msvc": "14.0.5-canary.58"
+                "@next/swc-darwin-arm64": "14.1.1-canary.1",
+                "@next/swc-darwin-x64": "14.1.1-canary.1",
+                "@next/swc-linux-arm64-gnu": "14.1.1-canary.1",
+                "@next/swc-linux-arm64-musl": "14.1.1-canary.1",
+                "@next/swc-linux-x64-gnu": "14.1.1-canary.1",
+                "@next/swc-linux-x64-musl": "14.1.1-canary.1",
+                "@next/swc-win32-arm64-msvc": "14.1.1-canary.1",
+                "@next/swc-win32-ia32-msvc": "14.1.1-canary.1",
+                "@next/swc-win32-x64-msvc": "14.1.1-canary.1"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -107,7 +116,7 @@
         "docs/cache-handler-docs": {
             "version": "0.6.3",
             "dependencies": {
-                "next": "14.0.4",
+                "next": "14.1.0",
                 "nextra": "2.13.2",
                 "nextra-theme-docs": "2.13.2",
                 "react": "18.2.0",
@@ -115,7 +124,7 @@
             },
             "devDependencies": {
                 "@neshca/tsconfig": "*",
-                "@next/eslint-plugin-next": "14.0.4",
+                "@next/eslint-plugin-next": "14.1.0",
                 "@types/node": "20.11.5",
                 "@types/react": "18.2.48",
                 "@types/react-dom": "18.2.18",
@@ -124,32 +133,21 @@
             }
         },
         "docs/cache-handler-docs/node_modules/@next/eslint-plugin-next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.4.tgz",
-            "integrity": "sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
+            "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
             "dev": true,
             "dependencies": {
-                "glob": "7.1.7"
+                "glob": "10.3.10"
             }
         },
-        "docs/cache-handler-docs/node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+        "docs/cache-handler-docs/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
             "dev": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "undici-types": "~5.26.4"
             }
         },
         "docs/cache-handler-docs/node_modules/nextra": {
@@ -250,6 +248,15 @@
                 "typescript": "5.3.3"
             }
         },
+        "internal/backend/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "internal/eslint-config-neshca": {
             "version": "0.0.0",
             "license": "MIT",
@@ -259,14 +266,14 @@
             }
         },
         "internal/eslint-config-neshca/node_modules/@next/eslint-plugin-next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.4.tgz",
-            "integrity": "sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
+            "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
             "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
-                "glob": "7.1.7"
+                "glob": "10.3.10"
             }
         },
         "internal/eslint-config-neshca/node_modules/@vercel/style-guide": {
@@ -319,34 +326,12 @@
                 }
             }
         },
-        "internal/eslint-config-neshca/node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "internal/next-common": {
             "name": "@neshca/next-common",
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "next": "14.0.5-canary.58"
+                "next": "14.1.1-canary.1"
             },
             "devDependencies": {
                 "@neshca/tsconfig": "*",
@@ -356,15 +341,24 @@
                 "typescript": "5.3.3"
             }
         },
-        "internal/next-common/node_modules/next": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.0.5-canary.58.tgz",
-            "integrity": "sha512-xZjkkbIDHCnzlV2M//0ehB72Wcxkw0yYsKqDr6+8VX9/BqBx8Z7mP/8d2ezF+c3lVcje6UODsmZW29IXpc5wKQ==",
+        "internal/next-common/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
             "dependencies": {
-                "@next/env": "14.0.5-canary.58",
+                "undici-types": "~5.26.4"
+            }
+        },
+        "internal/next-common/node_modules/next": {
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.1.1-canary.1.tgz",
+            "integrity": "sha512-17sG8plUzgT9xjdac11qFQUcF2JAgJ8h59U8ME1Ykaboy8sk7IkkD+HuOCJxREzsLtDh6Q8gqWxEAt+j9VuS/Q==",
+            "dependencies": {
+                "@next/env": "14.1.1-canary.1",
                 "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
-                "caniuse-lite": "^1.0.30001406",
+                "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",
                 "postcss": "8.4.31",
                 "styled-jsx": "5.1.1"
@@ -376,15 +370,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.0.5-canary.58",
-                "@next/swc-darwin-x64": "14.0.5-canary.58",
-                "@next/swc-linux-arm64-gnu": "14.0.5-canary.58",
-                "@next/swc-linux-arm64-musl": "14.0.5-canary.58",
-                "@next/swc-linux-x64-gnu": "14.0.5-canary.58",
-                "@next/swc-linux-x64-musl": "14.0.5-canary.58",
-                "@next/swc-win32-arm64-msvc": "14.0.5-canary.58",
-                "@next/swc-win32-ia32-msvc": "14.0.5-canary.58",
-                "@next/swc-win32-x64-msvc": "14.0.5-canary.58"
+                "@next/swc-darwin-arm64": "14.1.1-canary.1",
+                "@next/swc-darwin-x64": "14.1.1-canary.1",
+                "@next/swc-linux-arm64-gnu": "14.1.1-canary.1",
+                "@next/swc-linux-arm64-musl": "14.1.1-canary.1",
+                "@next/swc-linux-x64-gnu": "14.1.1-canary.1",
+                "@next/swc-linux-x64-musl": "14.1.1-canary.1",
+                "@next/swc-win32-arm64-msvc": "14.1.1-canary.1",
+                "@next/swc-win32-ia32-msvc": "14.1.1-canary.1",
+                "@next/swc-win32-x64-msvc": "14.1.1-canary.1"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -417,6 +411,15 @@
                 "typescript": "5.3.3"
             }
         },
+        "internal/next-lru-cache/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "internal/prettier-config": {
             "name": "@neshca/prettier-config",
             "version": "0.0.0",
@@ -426,14 +429,14 @@
             }
         },
         "internal/prettier-config/node_modules/@next/eslint-plugin-next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.4.tgz",
-            "integrity": "sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
+            "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
             "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
-                "glob": "7.1.7"
+                "glob": "10.3.10"
             }
         },
         "internal/prettier-config/node_modules/@vercel/style-guide": {
@@ -484,28 +487,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "internal/prettier-config/node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "internal/tsconfig": {
@@ -1824,11 +1805,6 @@
                 "fs-extra": "^8.1.0"
             }
         },
-        "node_modules/@manypkg/find-root/node_modules/@types/node": {
-            "version": "12.20.55",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-        },
         "node_modules/@manypkg/find-root/node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2190,43 +2166,23 @@
             "link": true
         },
         "node_modules/@next/env": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.5-canary.58.tgz",
-            "integrity": "sha512-HivKr1b1jXNZ/NsGlRaBucZTQIkwtE52QBJZLyygsxXLMPC7ng6oOY3DkWiiLxV4T38etNKKIrKVH8DZSjdWlQ=="
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.1-canary.1.tgz",
+            "integrity": "sha512-hkxKhWvFieo9wYuRcsQtDtHzZrs+spjxglCU9QLdwpSsRwifr1oxm+UvuhCNTQ7V8qZZPSEnhU0FMWIv3oo6Eg=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.5-canary.58.tgz",
-            "integrity": "sha512-0eEAkc70Rr/aAmcw2Gp0hNvU9YPURPr6e9ialJFknBLWkTtQvzQ+MM8x4MA259r41FwjtRa+BzQIxpAA0nFfFw==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.1-canary.1.tgz",
+            "integrity": "sha512-NerzDeqcUMbTuU/yc3NkDh7HOqZSEHNCEcUmmtEWhE17YLOt36necRQsfCbCFarRyWOWVJz2BMJbR2E8PqKrLw==",
             "dev": true,
             "dependencies": {
-                "glob": "7.1.7"
-            }
-        },
-        "node_modules/@next/eslint-plugin-next/node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "glob": "10.3.10"
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.5-canary.58.tgz",
-            "integrity": "sha512-FDmoxGMy1v0XREXDbdYutdn4xJ6edxOf/zg4piNbqxX3mHLfQiy4UZL1cd5wHMLZuWsOvb+DeivJhI+36oLfOQ==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.1-canary.1.tgz",
+            "integrity": "sha512-HA5F+iKomodTwoHNd7ABsluFQ/I34PfEd1LUMBPMvERwwGj6NEUYRqv/4nSqpGAkHK6FR2tM2uWi+dYHWNTAwA==",
             "cpu": [
                 "arm64"
             ],
@@ -2239,9 +2195,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.5-canary.58.tgz",
-            "integrity": "sha512-dLvi37j6hxt3n/3HChkwo2Hms5y6VRQpO29b2Rw/uH61LARS9jcdHPvbfGKb9Bssy/MD0UkOIxR+73V2OHldqw==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1-canary.1.tgz",
+            "integrity": "sha512-pWNXORRMVmA4G7LQRWBFTM4kM6TPFyQ+4NwySjpjZQqVAUb8jGh9npbjbd2XcCLbX/b/TbrHSERKpWekvmbvdQ==",
             "cpu": [
                 "x64"
             ],
@@ -2254,9 +2210,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.5-canary.58.tgz",
-            "integrity": "sha512-XDc/TGmSlu8KkVQex+z8OJqOu9J4It7+9b56bCRMHYuYaZrm0lUUTznw4DMsJExc+iwaW6XCTVeFYM4z6Ssj1w==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1-canary.1.tgz",
+            "integrity": "sha512-l3fDk5m8rbYHdwywqOP8Om99gUZ4HSodG25IZQqooATYtoBG3MeVkTTFwfn2JPtsuq6+BAwWNjrxZsbpJ3JK+g==",
             "cpu": [
                 "arm64"
             ],
@@ -2269,9 +2225,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.5-canary.58.tgz",
-            "integrity": "sha512-zoPz3ry3mwn970CKFizLfGweimOit0YV2J3yMb43OwPgi2PHuHBaUswL6Akv1t8P1Ny5wccy1A7rkdg+ypqa1Q==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1-canary.1.tgz",
+            "integrity": "sha512-qOs7Sno0MVyQqV/M9oxv9UvpB71GdeYhftX7EHB3gqJ7FnRs55Nw7vfES1qsaZ9h8Yd5tHjmq0VnXZnvzf6svg==",
             "cpu": [
                 "arm64"
             ],
@@ -2284,9 +2240,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.5-canary.58.tgz",
-            "integrity": "sha512-PF+lgu05TsS8bYiok6vW07r+46XPkTvJWBC44buoOP7dzA7h8EFjav/rnxtTW0nOtiEDtx7Z6bXhte2N8kIlXw==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1-canary.1.tgz",
+            "integrity": "sha512-uq2dwhacwwxnOXl5NSFbsbvU6ldAKIRde0mD+7edYSldhQUwDWLJQjqhImWd4+zSTWoTmTnEgkMgFgsPzgJnhQ==",
             "cpu": [
                 "x64"
             ],
@@ -2299,9 +2255,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.5-canary.58.tgz",
-            "integrity": "sha512-/vwqLbJlu/SfpntfLyeCPbUV9sUeSZjFqrjrmgQUoIJ2iKDcHh3USQe40Kj5yRR3V3y2mAoTQh4gnpv+OnB8mw==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1-canary.1.tgz",
+            "integrity": "sha512-fC4hAjpDU9JqQleqoozqbDUPT5QzvZO6RFVbolwQ8lPkY9mjcyICx/4DtQmoXy+GgWbPMqiMYRgnT6wGyvyreg==",
             "cpu": [
                 "x64"
             ],
@@ -2314,9 +2270,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.5-canary.58.tgz",
-            "integrity": "sha512-X8ptdLqjhPObaJuOGMy5SKY8vsXgJ9MRKMYmH5eGdq2bMYy1/uuH3nSigtmayAb6cvVNeT24FsI9g0P4KMWQTA==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1-canary.1.tgz",
+            "integrity": "sha512-UkeFvu4o8Hnze9oyBn9HDxl2l4eo9MJvZHxzRidcwX7xO68EkzQp3c2lZzRhxp14YfSya+5VKrOcZcduZsXPOw==",
             "cpu": [
                 "arm64"
             ],
@@ -2329,9 +2285,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.5-canary.58.tgz",
-            "integrity": "sha512-iSjSss2j574aHzKw4dO46V8yPARVVYej0P9QH46gKGdcnY97XyW4MjzxLIbhlPR4GV4qXshdB1MoejLIaI1uoA==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1-canary.1.tgz",
+            "integrity": "sha512-/QMAp34HyzYxT0VVaSvjgXmuUHSeJPRizm8SB4h0vG8M0/Pf8WPKsLf4TJVPOJkCjKd78f/EF8Hq7pngSDRihA==",
             "cpu": [
                 "ia32"
             ],
@@ -2344,9 +2300,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.0.5-canary.58",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.5-canary.58.tgz",
-            "integrity": "sha512-AFl0lgpmLdqHkrBsc2vrZx6mE6zLvKJWonUDS17q5akYsnQ2o9tPrtzFvhU1SYtmt5XD49SbfArPBRmTseFq0A==",
+            "version": "14.1.1-canary.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1-canary.1.tgz",
+            "integrity": "sha512-7TuIOK1saa9Ph61lmqUCEPbjuQOBio/U5VIjdP+/6Ux9ECzxmhMjnWamYKgLJXJ8Vn4AGmczHDPB25inJRKs1g==",
             "cpu": [
                 "x64"
             ],
@@ -2515,9 +2471,9 @@
             }
         },
         "node_modules/@pkgr/core": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.0.tgz",
-            "integrity": "sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+            "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
             "dev": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -2955,9 +2911,9 @@
             ]
         },
         "node_modules/@rushstack/eslint-patch": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.1.tgz",
-            "integrity": "sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.0.tgz",
+            "integrity": "sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==",
             "dev": true
         },
         "node_modules/@swc/helpers": {
@@ -2969,9 +2925,9 @@
             }
         },
         "node_modules/@tanstack/react-virtual": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.1.tgz",
-            "integrity": "sha512-IFOFuRUTaiM/yibty9qQ9BfycQnYXIDHGP2+cU+0LrFFGNhVxCXSQnaY6wkX8uJVteFEBjUondX0Hmpp7TNcag==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.2.tgz",
+            "integrity": "sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==",
             "dependencies": {
                 "@tanstack/virtual-core": "3.0.0"
             },
@@ -3121,17 +3077,14 @@
             "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
         },
         "node_modules/@types/node": {
-            "version": "20.11.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
-            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
-            "dependencies": {
-                "undici-types": "~5.26.4"
-            }
+            "version": "12.20.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+            "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
         },
         "node_modules/@types/node-fetch": {
-            "version": "2.6.10",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.10.tgz",
-            "integrity": "sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==",
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+            "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
             "peer": true,
             "dependencies": {
                 "@types/node": "*",
@@ -4166,9 +4119,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001576",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-            "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+            "version": "1.0.30001579",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+            "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -5478,9 +5431,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.630",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
-            "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg==",
+            "version": "1.4.639",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.639.tgz",
+            "integrity": "sha512-CkKf3ZUVZchr+zDpAlNLEEy2NJJ9T64ULWaDgy3THXXlPVPkLu3VOs9Bac44nebVtdwl2geSj6AxTtGDOxoXhg==",
             "dev": true
         },
         "node_modules/elkjs": {
@@ -7616,11 +7569,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-        },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -9330,12 +9278,12 @@
             }
         },
         "node_modules/match-sorter": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-            "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.3.tgz",
+            "integrity": "sha512-sgiXxrRijEe0SzHKGX4HouCpfHRPnqteH42UdMEW7BlWy990ZkzcvonJGv4Uu9WE7Y1f8Yocm91+4qFPCbmNww==",
             "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "remove-accents": "0.4.2"
+                "@babel/runtime": "^7.23.8",
+                "remove-accents": "0.5.0"
             }
         },
         "node_modules/md5": {
@@ -10949,18 +10897,17 @@
             }
         },
         "node_modules/next": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
-            "integrity": "sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+            "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
             "dependencies": {
-                "@next/env": "14.0.4",
+                "@next/env": "14.1.0",
                 "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
-                "caniuse-lite": "^1.0.30001406",
+                "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",
                 "postcss": "8.4.31",
-                "styled-jsx": "5.1.1",
-                "watchpack": "2.4.0"
+                "styled-jsx": "5.1.1"
             },
             "bin": {
                 "next": "dist/bin/next"
@@ -10969,15 +10916,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.0.4",
-                "@next/swc-darwin-x64": "14.0.4",
-                "@next/swc-linux-arm64-gnu": "14.0.4",
-                "@next/swc-linux-arm64-musl": "14.0.4",
-                "@next/swc-linux-x64-gnu": "14.0.4",
-                "@next/swc-linux-x64-musl": "14.0.4",
-                "@next/swc-win32-arm64-msvc": "14.0.4",
-                "@next/swc-win32-ia32-msvc": "14.0.4",
-                "@next/swc-win32-x64-msvc": "14.0.4"
+                "@next/swc-darwin-arm64": "14.1.0",
+                "@next/swc-darwin-x64": "14.1.0",
+                "@next/swc-linux-arm64-gnu": "14.1.0",
+                "@next/swc-linux-arm64-musl": "14.1.0",
+                "@next/swc-linux-x64-gnu": "14.1.0",
+                "@next/swc-linux-x64-musl": "14.1.0",
+                "@next/swc-win32-arm64-msvc": "14.1.0",
+                "@next/swc-win32-ia32-msvc": "14.1.0",
+                "@next/swc-win32-x64-msvc": "14.1.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -11034,14 +10981,14 @@
             }
         },
         "node_modules/next/node_modules/@next/env": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.4.tgz",
-            "integrity": "sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ=="
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
+            "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw=="
         },
         "node_modules/next/node_modules/@next/swc-darwin-arm64": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
-            "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+            "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11054,9 +11001,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-darwin-x64": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
-            "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+            "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
             "cpu": [
                 "x64"
             ],
@@ -11069,9 +11016,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
-            "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+            "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11084,9 +11031,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
-            "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+            "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
             "cpu": [
                 "arm64"
             ],
@@ -11099,9 +11046,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz",
-            "integrity": "sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+            "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
             "cpu": [
                 "x64"
             ],
@@ -11114,9 +11061,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz",
-            "integrity": "sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+            "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
             "cpu": [
                 "x64"
             ],
@@ -11129,9 +11076,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
-            "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+            "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11144,9 +11091,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
-            "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+            "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
             "cpu": [
                 "ia32"
             ],
@@ -11159,9 +11106,9 @@
             }
         },
         "node_modules/next/node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.0.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
-            "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+            "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
             "cpu": [
                 "x64"
             ],
@@ -11468,9 +11415,9 @@
             }
         },
         "node_modules/openai/node_modules/@types/node": {
-            "version": "18.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.7.tgz",
-            "integrity": "sha512-IGRJfoNX10N/PfrReRZ1br/7SQ+2vF/tK3KXNwzXz82D32z5dMQEoOlFew18nLSN+vMNcLY4GrKfzwi/yWI8/w==",
+            "version": "18.19.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+            "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
             "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -12976,9 +12923,9 @@
             }
         },
         "node_modules/remove-accents": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-            "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+            "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -15559,18 +15506,6 @@
             "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
             "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
         },
-        "node_modules/watchpack": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-            "dependencies": {
-                "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/wcwidth": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -16041,6 +15976,15 @@
                 "redis": ">=4.6"
             }
         },
+        "packages/cache-handler/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "packages/diffscribe": {
             "version": "0.2.1",
             "license": "MIT",
@@ -16060,6 +16004,15 @@
                 "openai": "^4.12.3"
             }
         },
+        "packages/diffscribe/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
         "packages/json-replacer-reviver": {
             "name": "@neshca/json-replacer-reviver",
             "version": "1.1.0",
@@ -16072,6 +16025,15 @@
                 "tsup": "8.0.1",
                 "tsx": "4.7.0",
                 "typescript": "5.3.3"
+            }
+        },
+        "packages/json-replacer-reviver/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
         "packages/server": {
@@ -16095,6 +16057,15 @@
                 "tsup": "8.0.1",
                 "tsx": "4.7.0",
                 "typescript": "5.3.3"
+            }
+        },
+        "packages/server/node_modules/@types/node": {
+            "version": "20.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+            "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         }
     }

--- a/packages/cache-handler/src/cache-handler.ts
+++ b/packages/cache-handler/src/cache-handler.ts
@@ -845,4 +845,8 @@ export class IncrementalCache implements CacheHandler {
                 throw new Error("Invariant: Can't determine file path kind");
         }
     }
+
+    resetRequestCache(): void {
+        // not implemented yet
+    }
 }


### PR DESCRIPTION
This pull request updates the Next.js dependencies to version 14.1.0 with stabilized `cacheHandler` option. The cacheHandler is now set to `cacheHandler` instead of `experimental.incrementalCacheHandlerPath`.