### PR TITLE
Fix misleading cache-handler.js file configurations in docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,15 +4,9 @@
     "[json]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "[md]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
     "[mdx]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.wordWrap": "on"
-    },
-    "[yml]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "typescript.surveys.enabled": false,
     "explorer.fileNesting.enabled": true,
@@ -32,6 +26,9 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[typescriptreact]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[javascript]": {
         "editor.defaultFormatter": "biomejs.biome"
     }
 }

--- a/apps/cache-testing/cache-handler-redis-stack.mjs
+++ b/apps/cache-testing/cache-handler-redis-stack.mjs
@@ -4,18 +4,18 @@ import createRedisCache from '@neshca/cache-handler/redis-stack';
 import createRedisStringsCache from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
-if (!process.env.REDIS_URL) {
-    console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
-}
-
-const client = createClient({
-    url: process.env.REDIS_URL,
-    name: `cache-handler:${process.env.PORT ?? process.pid}`,
-});
-
-client.on('error', () => {});
-
 IncrementalCache.onCreation(async () => {
+    if (!process.env.REDIS_URL) {
+        console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
+    }
+
+    const client = createClient({
+        url: process.env.REDIS_URL,
+        name: `cache-handler:${process.env.PORT ?? process.pid}`,
+    });
+
+    client.on('error', () => {});
+
     console.info('Connecting Redis client...');
     await client.connect();
     console.info('Redis client connected.');

--- a/apps/cache-testing/cache-handler-redis-strings.mjs
+++ b/apps/cache-testing/cache-handler-redis-strings.mjs
@@ -3,20 +3,20 @@ import createLruCache from '@neshca/cache-handler/local-lru';
 import createRedisCache from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
-if (!process.env.REDIS_URL) {
-    console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
-}
-
-const PREFIX = 'string:';
-
-const client = createClient({
-    url: process.env.REDIS_URL,
-    name: `cache-handler:${PREFIX}${process.env.PORT ?? process.pid}`,
-});
-
-client.on('error', () => {});
-
 IncrementalCache.onCreation(async () => {
+    if (!process.env.REDIS_URL) {
+        console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
+    }
+
+    const PREFIX = 'string:';
+
+    const client = createClient({
+        url: process.env.REDIS_URL,
+        name: `cache-handler:${PREFIX}${process.env.PORT ?? process.pid}`,
+    });
+
+    client.on('error', () => {});
+
     console.info('Connecting Redis client...');
     await client.connect();
     console.info('Redis client connected.');

--- a/apps/cache-testing/cache-handler-server.mjs
+++ b/apps/cache-testing/cache-handler-server.mjs
@@ -1,13 +1,9 @@
-import Timers from 'node:timers/promises';
-
 import { IncrementalCache } from '@neshca/cache-handler';
 import createLruCache from '@neshca/cache-handler/local-lru';
 import createServerCache from '@neshca/cache-handler/server';
 
-const baseUrl = process.env.REMOTE_CACHE_SERVER_BASE_URL ?? 'http://localhost:8080';
-
 IncrementalCache.onCreation(async () => {
-    await Timers.scheduler.wait(1000);
+    const baseUrl = process.env.REMOTE_CACHE_SERVER_BASE_URL ?? 'http://localhost:8080';
 
     const httpCache = createServerCache({
         baseUrl,

--- a/docs/cache-handler-docs/src/pages/configuration/build-id-as-prefix-key.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/build-id-as-prefix-key.mdx
@@ -28,7 +28,7 @@ const nextConfig = {
 };
 ```
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async () => {
   await client.connect();
 
@@ -58,11 +58,7 @@ const nextConfig = {
 };
 ```
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createRedisCache = require('@neshca/cache-handler/redis-stack').default;
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async ({ buildId }) => {
   let redisCache;
 

--- a/docs/cache-handler-docs/src/pages/configuration/cache.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/cache.mdx
@@ -6,8 +6,8 @@ The `onCreation` hook is used to configure a custom cache handler. The example b
 
 ### Example: Custom Cache Handler Implementation
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
 
 IncrementalCache.onCreation(async () => {
   const cacheStore = new Map();
@@ -28,7 +28,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="info">
@@ -45,7 +45,7 @@ For control over the revalidation process, implement `getRevalidatedTags` and `r
 
 ### Example: Custom Revalidation Methods
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 const revalidateTags = {};
 
 const cache = {
@@ -87,7 +87,7 @@ Structure of the `RevalidatedTags` object:
 
 Next.js modifies the global `fetch` function, which can lead to unexpected behavior when using `fetch` in custom cache handlers. To address this, use the following workaround when calling `fetch`:
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 const cache = {
   async get(key) {
     const response = await fetch(url, {

--- a/docs/cache-handler-docs/src/pages/configuration/development-environment.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/development-environment.mdx
@@ -6,11 +6,11 @@ The easiest way to turn off the cache handler in a development environment is to
 
 ```js filename="next.config.js" copy
 const nextConfig = {
-  cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.js') : undefined,
+  cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
   // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
   /* experimental: {
             incrementalCacheHandlerPath:
-                process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.js') : undefined,
+                process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
     }, */
 };
 ```

--- a/docs/cache-handler-docs/src/pages/configuration/on-creation.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/on-creation.mdx
@@ -37,7 +37,7 @@ When implementing the `onCreationHook`, you can utilize the information provided
 
 Here's a simplified example of how the `onCreation` method might be used:
 
-```js filename="cache-handler.js"
+```js filename="cache-handler.mjs"
 IncrementalCache.onCreation(async (context) => {
   const customCacheLogic = {
     // Define custom get, set, and other cache methods
@@ -71,7 +71,7 @@ The `CacheConfig` object defines the configuration for the cache system. It typi
 
 Here is an example of how the `onCreation` hook might be implemented and what the return value looks like:
 
-```js filename="cache-handler.js"
+```js filename="cache-handler.mjs"
 IncrementalCache.onCreation(async (context) => {
   const customCache = {
     // Custom cache methods like get, set, etc.

--- a/docs/cache-handler-docs/src/pages/configuration/opt-out-cache-on-build.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/opt-out-cache-on-build.mdx
@@ -4,9 +4,9 @@ There are scenarios, especially during deployment, where your Redis server may n
 
 ### Configuration Steps
 
-1. **Modify the `cache-handler.js` File**: Adjust the `onCreation` method in your `cache-handler.js` file to conditionally connect to the Redis cache. The modified code should look like this:
+1. **Modify the `cache-handler.mjs` File**: Adjust the `onCreation` method in your `cache-handler.mjs` file to conditionally connect to the Redis cache. The modified code should look like this:
 
-   ```js filename="cache-handler.js" copy
+   ```js filename="cache-handler.mjs" copy
    IncrementalCache.onCreation(async () => {
      let redisCache;
 

--- a/docs/cache-handler-docs/src/pages/configuration/ttl.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/ttl.mdx
@@ -19,7 +19,7 @@ In Next.js, ISR allows routes to be incrementally updated through the [`revalida
 
 Here's how to use TTL in preconfigured Handlers:
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async () => {
   await client.connect();
 
@@ -52,7 +52,7 @@ For custom cache handlers, here are examples for Redis:
 
 #### Redis Strings Example
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async () => {
   const cache = {
     // ... other cache methods ...
@@ -79,7 +79,7 @@ IncrementalCache.onCreation(async () => {
 
 #### Redis Stack Example
 
-```js filename="cache-handler.js" copy
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async () => {
   const cache = {
     // ... other cache methods ...
@@ -106,9 +106,8 @@ IncrementalCache.onCreation(async () => {
 
 #### Stale While Revalidate Example
 
-```js filename="cache-handler.js" copy
-const { calculateEvictionDelay } = require('@neshca/cache-handler/helpers');
-
+```js filename="cache-handler.mjs" copy
+import { calculateEvictionDelay } from 'neshca/cache-handler/helpers';
 // ...
 
 IncrementalCache.onCreation(async () => {

--- a/docs/cache-handler-docs/src/pages/configuration/use-file-system.mdx
+++ b/docs/cache-handler-docs/src/pages/configuration/use-file-system.mdx
@@ -6,8 +6,8 @@ You can use your file system to store the cache data alongside your shared cache
 
 The file system cache is enabled by default. You can disable it by setting `useFileSystem` to false in your `onCreation` hook:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
 
 IncrementalCache.onCreation(async () => {
   const cacheStore = new Map();
@@ -30,7 +30,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="warning">
@@ -60,11 +60,7 @@ The `createLruCache` function initializes the LRU cache handler. It includes met
 
 #### Example Usage
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createRedisCache = require('@neshca/cache-handler/redis-stack').default;
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-
+```js filename="cache-handler.mjs" copy
 IncrementalCache.onCreation(async (context) => {
   const createRedisCache = await createRedisCache({
     /* ... */

--- a/docs/cache-handler-docs/src/pages/installation.mdx
+++ b/docs/cache-handler-docs/src/pages/installation.mdx
@@ -43,42 +43,16 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
 ### Basic Custom Configuration
 
 1. **Create a Cache Handler File**:  
-   In your project root, create a file named `cache-handler.js` for your cache configuration.
+   In your project root, create a file named `cache-handler.mjs` for your cache configuration.
 
 2. **Configure the Cache Handler**:  
    Below is a basic setup example:
-
-   ```js filename="cache-handler.js" copy
-   const { IncrementalCache } = require('@neshca/cache-handler');
-
-   IncrementalCache.onCreation(async () => {
-     // Don't use Map in production. This is just an example.
-     const cacheStore = new Map();
-
-     const cache = {
-       async get(key) {
-         return cacheStore.get(key);
-       },
-       async set(key, value) {
-         cacheStore.set(key, value);
-       },
-     };
-
-     return {
-       cache,
-       useFileSystem: true,
-     };
-   });
-
-   module.exports = IncrementalCache;
-   ```
-
-   EcmaScript modules can be used by adding the `.mjs` extension to the file and using an `import` statement instead of a `require` call:
 
    ```js filename="cache-handler.mjs" copy
    import { IncrementalCache } from '@neshca/cache-handler';
 
    IncrementalCache.onCreation(async () => {
+     // Don't use Map in production. This is just an example.
      const cacheStore = new Map();
 
      const cache = {
@@ -105,11 +79,11 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
    ```js filename="next.config.js" copy
    const nextConfig = {
      // './cache-handler.mjs' in case you're using EcmaScript modules.
-     cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.js') : undefined,
+     cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
      // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
      /* experimental: {
            incrementalCacheHandlerPath:
-               process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.js') : undefined,
+               process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
        }, */
    };
 
@@ -118,7 +92,7 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
 
 <Callout type="info">
   Do not import <code>@neshca/cache-handler</code> to your components or pages. It is only meant to be used in{' '}
-  <code>cache-handler.js</code> files.
+  <code>cache-handler.mjs</code> files.
 </Callout>
 
 ### Running Your Application

--- a/docs/cache-handler-docs/src/pages/redis-stack-custom.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-stack-custom.mdx
@@ -7,24 +7,23 @@ import { Callout } from 'nextra/components';
   Redis instance. You can use any other way to set the URL.
 </Callout>
 
-Create a file called `cache-handler.js` next to you `next.config.js` with the following contents:
+Create a file called `cache-handler.mjs` next to you `next.config.js` with the following contents:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-const { createClient } = require('redis');
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
+import createLruCache from '@neshca/cache-handler/local-lru';
+import { createClient } from 'redis';
 
 const REVALIDATED_TAGS_KEY = 'sharedRevalidatedTags';
 
-const client = createClient({
-  url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-});
-
-client.on('error', (error) => {
-  console.error('Redis error:', error);
-});
-
 IncrementalCache.onCreation(async () => {
+  // always create a Redis client inside the `onCreation` callback
+  const client = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  });
+
+  client.on('error', (error) => {});
+
   await client.connect();
 
   // read more about TTL limitations https://caching-tools.github.io/next-shared-cache/configuration/ttl
@@ -100,7 +99,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="info">Ensure that the Redis instance is running when you build your Next.js app.</Callout>

--- a/docs/cache-handler-docs/src/pages/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-stack.mdx
@@ -7,23 +7,22 @@ import { Callout } from 'nextra/components';
   Redis instance. You can use any other way to set the URL.
 </Callout>
 
-Create a file called `cache-handler.js` next to you `next.config.js` with the following contents:
+Create a file called `cache-handler.mjs` next to you `next.config.js` with the following contents:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createRedisCache = require('@neshca/cache-handler/redis-stack').default;
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-const { createClient } = require('redis');
-
-const client = createClient({
-  url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-});
-
-client.on('error', (error) => {
-  console.error('Redis error:', error);
-});
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
+import createLruCache from '@neshca/cache-handler/local-lru';
+import createRedisCache from '@neshca/cache-handler/redis-stack';
+import { createClient } from 'redis';
 
 IncrementalCache.onCreation(async () => {
+  // always create a Redis client inside the `onCreation` callback
+  const client = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  });
+
+  client.on('error', () => {});
+
   // read more about TTL limitations https://caching-tools.github.io/next-shared-cache/configuration/ttl
   const useTtl = false;
 
@@ -47,7 +46,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="info">Ensure that the Redis instance is running when you build your Next.js app.</Callout>

--- a/docs/cache-handler-docs/src/pages/redis-strings-custom.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-strings-custom.mdx
@@ -13,25 +13,24 @@ npm i -D @neshca/json-replacer-reviver
   Redis instance. You can use any other way to set the URL.
 </Callout>
 
-Create a file called `cache-handler.js` next to your `next.config.js` with the following contents:
+Create a file called `cache-handler.mjs` next to your `next.config.js` with the following contents:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-const { reviveFromBase64Representation, replaceJsonWithBase64 } = require('@neshca/json-replacer-reviver');
-const { createClient } = require('redis');
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
+import createLruCache from '@neshca/cache-handler/local-lru';
+import { reviveFromBase64Representation, replaceJsonWithBase64 } from '@neshca/json-replacer-reviver';
+import { createClient } from 'redis';
 
 const REVALIDATED_TAGS_KEY = 'sharedRevalidatedTags';
 
-const client = createClient({
-  url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-});
-
-client.on('error', (error) => {
-  console.error('Redis error:', error);
-});
-
 IncrementalCache.onCreation(async () => {
+  // always create a Redis client inside the `onCreation` callback
+  const client = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  });
+
+  client.on('error', () => {});
+
   // read more about TTL limitations https://caching-tools.github.io/next-shared-cache/configuration/ttl
   const useTtl = false;
 
@@ -97,7 +96,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="info">Ensure that the Redis instance is running when you build your Next.js app.</Callout>

--- a/docs/cache-handler-docs/src/pages/redis-strings.mdx
+++ b/docs/cache-handler-docs/src/pages/redis-strings.mdx
@@ -7,23 +7,21 @@ import { Callout } from 'nextra/components';
   Redis instance. You can use any other way to set the URL.
 </Callout>
 
-Create a file called `cache-handler.js` next to your `next.config.js` with the following contents:
+Create a file called `cache-handler.mjs` next to your `next.config.js` with the following contents:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const createRedisCache = require('@neshca/cache-handler/redis-strings').default;
-const createLruCache = require('@neshca/cache-handler/local-lru').default;
-const { createClient } = require('redis');
-
-const client = createClient({
-  url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-});
-
-client.on('error', (error) => {
-  console.error('Redis error:', error);
-});
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
+import createLruCache from '@neshca/cache-handler/local-lru';
+import createRedisCache from '@neshca/cache-handler/redis-strings';
+import { createClient } from 'redis';
 
 IncrementalCache.onCreation(async () => {
+  const client = createClient({
+    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+  });
+
+  client.on('error', (error) => {});
+
   // read more about TTL limitations https://caching-tools.github.io/next-shared-cache/configuration/ttl
   const useTtl = false;
 
@@ -47,7 +45,7 @@ IncrementalCache.onCreation(async () => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```
 
 <Callout type="info">Ensure that the Redis instance is running when you build your Next.js app.</Callout>

--- a/docs/cache-handler-docs/src/pages/server.mdx
+++ b/docs/cache-handler-docs/src/pages/server.mdx
@@ -25,11 +25,12 @@ PORT=8080 HOST=localhost npx next-cache-server
   to the URL of your `@neshca/server`. You can use any other way to set the URL.
 </Callout>
 
-Create a file called `cache-handler.js` next to you `next.config.js` with the following contents:
+Create a file called `cache-handler.mjs` next to you `next.config.js` with the following contents:
 
-```js filename="cache-handler.js" copy
-const { IncrementalCache } = require('@neshca/cache-handler');
-const { createHandler } = require('@neshca/cache-handler/server');
+```js filename="cache-handler.mjs" copy
+import { IncrementalCache } from '@neshca/cache-handler';
+import createLruCache from '@neshca/cache-handler/local-lru';
+import createServerCache from '@neshca/cache-handler/server';
 
 const baseUrl = process.env.REMOTE_CACHE_SERVER_BASE_URL ?? 'http://localhost:8080';
 
@@ -46,5 +47,5 @@ IncrementalCache.onCreation(() => {
   };
 });
 
-module.exports = IncrementalCache;
+export default IncrementalCache;
 ```

--- a/docs/cache-handler-docs/src/pages/troubleshooting.mdx
+++ b/docs/cache-handler-docs/src/pages/troubleshooting.mdx
@@ -6,7 +6,7 @@ You can verify if the cache handler is active by using either of the following m
 
 Add `console.log` statements to your cache handler:
 
-```js filename="cache-handler.js"
+```js filename="cache-handler.mjs"
 /* ... */
 const cache = {
   async get(key) {

--- a/packages/cache-handler/src/cache-handler.ts
+++ b/packages/cache-handler/src/cache-handler.ts
@@ -128,7 +128,7 @@ export type CacheCreationContext = {
      *
      * @example
      * ```js
-     * // cache-handler.js
+     * // cache-handler.mjs
      * IncrementalCache.onCreation(async ({ buildId }) => {
      *   let redisCache;
      *
@@ -193,7 +193,7 @@ export class IncrementalCache implements CacheHandler {
      *
      * @example
      * ```js
-     * // cache-handler.js
+     * // cache-handler.mjs
      * IncrementalCache.onCreation(async () => {
      *  const = redisCache = await createRedisCache({
      *    client,


### PR DESCRIPTION
This pull request fixes the misleading docs related to the `cache-handler.mjs` file configurations.

Also applied this to a Next.js example: https://github.com/vercel/next.js/pull/61488

Closes #284