### PR TITLE
Refactor cache-handler 2

### DIFF
--- a/apps/cache-testing/package.json
+++ b/apps/cache-testing/package.json
@@ -23,7 +23,6 @@
     },
     "devDependencies": {
         "@neshca/cache-handler": "*",
-        "@neshca/json-replacer-reviver": "*",
         "@next/eslint-plugin-next": "14.1.1-canary.27",
         "@playwright/test": "1.41.2",
         "@repo/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16690,7 +16690,6 @@
             "version": "0.6.10",
             "license": "MIT",
             "dependencies": {
-                "@neshca/json-replacer-reviver": "*",
                 "lru-cache": "10.2.0"
             },
             "devDependencies": {

--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -66,7 +66,6 @@
         "test:watch": "node --watch --test --import tsx/esm src/**/*.test.ts"
     },
     "dependencies": {
-        "@neshca/json-replacer-reviver": "*",
         "lru-cache": "10.2.0"
     },
     "devDependencies": {

--- a/packages/cache-handler/src/handlers/redis-stack.ts
+++ b/packages/cache-handler/src/handlers/redis-stack.ts
@@ -86,22 +86,10 @@ export default async function createCache<T extends RedisClientType>({
                 keyPrefix + key,
             )) as CacheHandlerValue | null;
 
-            if (cacheValue?.value?.kind === 'ROUTE') {
-                cacheValue.value.body = Buffer.from(cacheValue.value.body as unknown as string, 'base64');
-            }
-
             return cacheValue;
         },
         async set(key, cacheHandlerValue) {
             assertClientIsReady();
-
-            let preparedCacheValue = cacheHandlerValue;
-
-            if (cacheHandlerValue.value?.kind === 'ROUTE') {
-                preparedCacheValue = structuredClone(cacheHandlerValue);
-                // @ts-expect-error -- object must have the same shape as cacheValue
-                preparedCacheValue.value.body = cacheHandlerValue.value.body.toString('base64') as unknown as Buffer;
-            }
 
             const options = getTimeoutRedisCommandOptions(timeoutMs);
 
@@ -111,7 +99,7 @@ export default async function createCache<T extends RedisClientType>({
                 options,
                 keyPrefix + key,
                 '.',
-                preparedCacheValue as unknown as RedisJSON,
+                cacheHandlerValue as unknown as RedisJSON,
             );
 
             const expireCacheValue = cacheHandlerValue.lifespan

--- a/packages/cache-handler/src/handlers/redis-strings.ts
+++ b/packages/cache-handler/src/handlers/redis-strings.ts
@@ -1,4 +1,3 @@
-import { replaceJsonWithBase64, reviveFromBase64Representation } from '@neshca/json-replacer-reviver';
 import type { RedisClientType } from 'redis';
 
 import type { CacheHandlerValue, Handler } from '../cache-handler';
@@ -55,23 +54,18 @@ export default function createCache<T extends RedisClientType>({
                 return null;
             }
 
-            // use reviveFromBase64Representation to restore binary data from Base64
-            const data = JSON.parse(result, reviveFromBase64Representation) as CacheHandlerValue | null;
-
-            return data;
+            return JSON.parse(result) as CacheHandlerValue | null;
         },
         async set(key, cacheHandlerValue) {
             assertClientIsReady();
 
             const options = getTimeoutRedisCommandOptions(timeoutMs);
 
-            const isRouteKind = cacheHandlerValue.value?.kind === 'ROUTE';
-
             const setOperation = client.set(
                 options,
                 keyPrefix + key,
                 // use replaceJsonWithBase64 to store binary data in Base64 and save space for ROUTE kind
-                JSON.stringify(cacheHandlerValue, isRouteKind ? replaceJsonWithBase64 : undefined),
+                JSON.stringify(cacheHandlerValue),
             );
 
             const expireOperation = cacheHandlerValue.lifespan

--- a/packages/cache-handler/src/handlers/server.ts
+++ b/packages/cache-handler/src/handlers/server.ts
@@ -1,5 +1,3 @@
-import { replaceJsonWithBase64, reviveFromBase64Representation } from '@neshca/json-replacer-reviver';
-
 import type { CacheHandlerValue, Handler } from '../cache-handler';
 
 export type ServerCacheHandlerOptions = {
@@ -62,19 +60,14 @@ export default function createCache({ baseUrl, timeoutMs }: ServerCacheHandlerOp
 
             const string = await response.text();
 
-            return JSON.parse(string, reviveFromBase64Representation) as CacheHandlerValue;
+            return JSON.parse(string) as CacheHandlerValue;
         },
         async set(key, cacheHandlerValue) {
             const url = new URL('/set', baseUrl);
 
-            const isRouteKind = cacheHandlerValue.value?.kind === 'ROUTE';
-
             const response = await fetch(url, {
                 method: 'POST',
-                body: JSON.stringify([
-                    key,
-                    JSON.stringify(cacheHandlerValue, isRouteKind ? replaceJsonWithBase64 : undefined),
-                ]),
+                body: JSON.stringify([key, JSON.stringify(cacheHandlerValue)]),
                 headers: {
                     'Content-Type': 'application/json',
                 },

--- a/packages/cache-handler/tsup.config.ts
+++ b/packages/cache-handler/tsup.config.ts
@@ -9,5 +9,5 @@ export const tsup = defineConfig({
     format: ['cjs', 'esm'],
     dts: { resolve: true },
     target: 'node18',
-    noExternal: ['@neshca/json-replacer-reviver', 'lru-cache'],
+    noExternal: ['lru-cache'],
 });

--- a/packages/json-replacer-reviver/README.md
+++ b/packages/json-replacer-reviver/README.md
@@ -38,7 +38,7 @@ console.log(parsed); // <Buffer 68 65 6c 6c 6f>
 
 ## Developing and contributing
 
-[Developing and contributing in this monorepo](../../docs/contributing/monorepo.md)
+[Developing and contributing to this monorepo](../../docs/contributing/monorepo.md)
 
 ### Running tests locally
 


### PR DESCRIPTION
### Breaking Changes

#### `@neshca/cache-handler`

- encapsulate `Buffer` to `base64` convertation to the `ROUTE` kind values
- make file system related methods static

#### Pre-configured handlers

- remove `@neshca/json-replacer-reviver` from deps

### Fixes

#### `@neshca/cache-handler`

- refactor constructor to prevent multiple `CacheHandler.#configureCacheHandler` calls