### PR TITLE
Fix redis Handlers revalidateTag method

### DIFF
--- a/.changeset/witty-beers-call.md
+++ b/.changeset/witty-beers-call.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Fix Redis Handlers `revalidateTag` method

--- a/packages/cache-handler/src/handlers/redis-strings.ts
+++ b/packages/cache-handler/src/handlers/redis-strings.ts
@@ -98,6 +98,10 @@ export default function createHandler<T extends RedisClientType>({
                 }
             }
 
+            if (keysToDelete.length === 0) {
+                return;
+            }
+
             const options = getTimeoutRedisCommandOptions(timeoutMs);
 
             const deleteKeysOperation = client.del(options, keysToDelete);


### PR DESCRIPTION
This pull request fixes the revalidateTag method in the redis Handlers modules. This method caused errors when there were no keys to delete.