### PR TITLE
Fix Redis client type in Redis Handlers

### DIFF
--- a/.changeset/shiny-pandas-rule.md
+++ b/.changeset/shiny-pandas-rule.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Fix Redis client type in Redis Handlers

--- a/apps/cache-testing/cache-handler-local.mjs
+++ b/apps/cache-testing/cache-handler-local.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 

--- a/apps/cache-testing/cache-handler-redis-stack.mjs
+++ b/apps/cache-testing/cache-handler-redis-stack.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-stack';

--- a/apps/cache-testing/cache-handler-redis-strings.mjs
+++ b/apps/cache-testing/cache-handler-redis-strings.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-strings';
@@ -10,6 +12,7 @@ CacheHandler.onCreation(async () => {
 
     const PREFIX = 'string:';
 
+    /** @type {import("redis").RedisClientType} */
     const client = createClient({
         url: process.env.REDIS_URL,
         name: `cache-handler:${PREFIX}${process.env.PORT ?? process.pid}`,

--- a/apps/cache-testing/cache-handler-server.mjs
+++ b/apps/cache-testing/cache-handler-server.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createServerHandler from '@neshca/cache-handler/server';

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -1,3 +1,28 @@
-import type { RedisClientType } from 'redis';
+import type { RedisClientType, createClient } from 'redis';
 
 export type RedisJSON = Parameters<RedisClientType['json']['set']>['2'];
+
+/**
+ * The configuration options for the Redis Handler
+ */
+export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> = {
+    /**
+     * The Redis client instance.
+     */
+    client: T;
+    /**
+     * Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
+     */
+    keyPrefix?: string;
+    /**
+     * Timeout in milliseconds for Redis operations. Defaults to 5000.
+     */
+    timeoutMs?: number;
+};
+
+export type CreateRedisStringsHandlerOptions = CreateRedisStackHandlerOptions & {
+    /**
+     * Optional. Key for storing cache tags. Defaults to `__sharedTags__`.
+     */
+    sharedTagsKey?: string;
+};

--- a/packages/cache-handler/src/handlers/redis-stack.ts
+++ b/packages/cache-handler/src/handlers/redis-stack.ts
@@ -1,30 +1,10 @@
-import { type RedisClientType, SchemaFieldTypes } from 'redis';
+import { SchemaFieldTypes } from 'redis';
 
 import type { CacheHandlerValue, Handler } from '../cache-handler';
-import type { RedisJSON } from '../common-types';
+import type { CreateRedisStackHandlerOptions, RedisJSON } from '../common-types';
 import { getTimeoutRedisCommandOptions } from '../helpers/get-timeout-redis-command-options';
 
-/**
- * The configuration options for the Redis Handler
- */
-export type RedisCacheHandlerOptions<T> = {
-    /**
-     * The Redis client instance.
-     */
-    client: T;
-    /**
-     * Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
-     */
-    keyPrefix?: string;
-    /**
-     * Optional. Key for storing cache tags. Defaults to `__sharedTags__`.
-     */
-    sharedTagsKey?: string;
-    /**
-     * Timeout in milliseconds for Redis operations. Defaults to 5000.
-     */
-    timeoutMs?: number;
-};
+export { CreateRedisStackHandlerOptions };
 
 /**
  * Creates a Handler using Redis client.
@@ -33,14 +13,14 @@ export type RedisCacheHandlerOptions<T> = {
  * It supports Redis Client. The handler includes
  * methods to get, set, and manage cache values and revalidated tags.
  *
- * @param options - The configuration options for the Redis Handler. See {@link RedisCacheHandlerOptions}.
+ * @param options - The configuration options for the Redis Stack Handler. See {@link CreateRedisStackHandlerOptions}.
  *
  * @returns A promise that resolves to object representing the cache, with methods for cache operations.
  *
  * @example
  * ```js
  * const redisClient = createRedisClient(...);
- * const cache = await createHandler({
+ * const handler = await createHandler({
  *   client: redisClient,
  *   keyPrefix: 'myApp:',
  * });
@@ -51,11 +31,11 @@ export type RedisCacheHandlerOptions<T> = {
  * - the `set` method allows setting a value in the cache.
  * - the `revalidateTag` methods are used for handling tag-based cache revalidation.
  */
-export default async function createHandler<T extends RedisClientType>({
+export default async function createHandler({
     client,
     keyPrefix = '',
     timeoutMs = 5000,
-}: Omit<RedisCacheHandlerOptions<T>, 'sharedTagsKey'>): Promise<Handler> {
+}: CreateRedisStackHandlerOptions): Promise<Handler> {
     function assertClientIsReady(): void {
         if (!client.isReady) {
             throw new Error('Redis client is not ready');
@@ -127,9 +107,7 @@ export default async function createHandler<T extends RedisClientType>({
 
             const options = getTimeoutRedisCommandOptions(timeoutMs);
 
-            const deleteKeysOperation = client.del(options, keysToDelete);
-
-            await Promise.all([deleteKeysOperation]);
+            await client.del(options, keysToDelete);
         },
     };
 }

--- a/packages/cache-handler/src/handlers/redis-strings.ts
+++ b/packages/cache-handler/src/handlers/redis-strings.ts
@@ -1,9 +1,11 @@
-import type { RedisClientType } from 'redis';
+// import type { RedisClientType } from 'redis';
 
 import type { CacheHandlerValue, Handler } from '../cache-handler';
+import type { CreateRedisStringsHandlerOptions } from '../common-types';
+
 import { getTimeoutRedisCommandOptions } from '../helpers/get-timeout-redis-command-options';
 
-import type { RedisCacheHandlerOptions } from './redis-stack';
+export { CreateRedisStringsHandlerOptions };
 
 /**
  * Creates a Handler using Redis client.
@@ -12,7 +14,7 @@ import type { RedisCacheHandlerOptions } from './redis-stack';
  * It supports both Redis Client and Redis Cluster types. The handler includes
  * methods to get, set, and manage cache values and revalidated tags.
  *
- * @param options - The configuration options for the Redis Handler. See {@link RedisCacheHandlerOptions}.
+ * @param options - The configuration options for the Redis Handler. See {@link CreateRedisStringsHandlerOptions}.
  *
  * @returns An object representing the cache, with methods for cache operations.
  *
@@ -31,12 +33,12 @@ import type { RedisCacheHandlerOptions } from './redis-stack';
  * - the `set` method allows setting a value in the cache.
  * - the `revalidateTag` methods are used for handling tag-based cache revalidation.
  */
-export default function createHandler<T extends RedisClientType>({
+export default function createHandler({
     client,
     keyPrefix = '',
     sharedTagsKey = '__sharedTags__',
     timeoutMs = 5000,
-}: RedisCacheHandlerOptions<T>): Handler {
+}: CreateRedisStringsHandlerOptions): Handler {
     function assertClientIsReady(): void {
         if (!client.isReady) {
             throw new Error('Redis client is not ready yet or connection is lost. Keep trying...');


### PR DESCRIPTION
This pull request fixes the Redis client type in the Redis Handlers modules. The Redis client type was incorrectly defined, causing errors in the code with ts-check directive.

Fix #364