### PR TITLE
Fix body mutation of ROUTE kind values

### DIFF
--- a/.changeset/friendly-cherries-mate.md
+++ b/.changeset/friendly-cherries-mate.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Fix body mutation of the ROUTE kind values.

--- a/apps/cache-testing/cache-handler-next-example.js
+++ b/apps/cache-testing/cache-handler-next-example.js
@@ -1,0 +1,35 @@
+const cache = new Map();
+
+module.exports = class CacheHandler {
+    constructor(options) {
+        this.options = options;
+    }
+
+    // biome-ignore lint/nursery/useAwait: don't bother
+    async get(key) {
+        // This could be stored anywhere, like durable storage
+        return cache.get(key);
+    }
+
+    // biome-ignore lint/nursery/useAwait: don't bother
+    async set(key, data, ctx) {
+        // This could be stored anywhere, like durable storage
+        cache.set(key, {
+            value: data,
+            lastModified: Date.now(),
+            tags: ctx.tags,
+        });
+    }
+
+    // biome-ignore lint/nursery/useAwait: don't bother
+    async revalidateTag(tag) {
+        // Iterate over all entries in the cache
+        // biome-ignore lint/style/useConst: don't bother
+        for (let [key, value] of cache) {
+            // If the value's tags include the specified tag, delete this entry
+            if (value.tags.includes(tag)) {
+                cache.delete(key);
+            }
+        }
+    }
+};

--- a/apps/cache-testing/src/app/app/static/route.ts
+++ b/apps/cache-testing/src/app/app/static/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+    return Promise.resolve(new Response('OK', { status: 200 }));
+}

--- a/apps/cache-testing/tests/app.spec.ts
+++ b/apps/cache-testing/tests/app.spec.ts
@@ -322,3 +322,15 @@ test.describe('SSR', () => {
         expect(valueFromPageAfterReload - valueFromPage === 1).toBe(true);
     });
 });
+
+test.describe('Routes', () => {
+    test('static route return OK', async ({ page, baseURL }) => {
+        const url = new URL('/app/static', `${baseURL}:3000`);
+
+        await page.goto(url.href);
+
+        const message = await page.getByText('OK').innerText();
+
+        expect(message).toBe('OK');
+    });
+});


### PR DESCRIPTION
This pull request fixes the issue of body mutation in ROUTE kind values. It includes changes to the `CacheHandler` class `set` method. The ROUTE kind values are now shallowly copied before mutation.