### PR TITLE
Implement `revalidatePath` functionality for the App Router

### DIFF
--- a/.changeset/long-sheep-play.md
+++ b/.changeset/long-sheep-play.md
@@ -1,0 +1,29 @@
+---
+'@neshca/cache-handler': minor
+---
+
+Add `revalidatePath` functionality.
+
+#### New Features
+
+##### `@neshca/cache-handler`
+
+- add `implicitTags` parameter to the `get` method for Handlers
+- remove implicit tags filtration for the `PAGE` kind cache values
+
+##### `@neshca/cache-handle/local-lru`
+
+- implement `revalidatePath` functionality
+
+##### `@neshca/cache-handle/redis-stack`
+
+- implement `revalidatePath` functionality
+
+##### `@neshca/cache-handle/redis-strings`
+
+- implement `revalidatePath` functionality
+- refactor `revalidateTag` method to use `HSCAN` instead of `HGETALL`
+
+##### `@neshca/cache-handle/helpers`
+
+- add `isImplicitTag` and `getTimeoutRedisCommandOptions` functions

--- a/.changeset/tricky-cobras-pull.md
+++ b/.changeset/tricky-cobras-pull.md
@@ -1,0 +1,5 @@
+---
+'@neshca/server': minor
+---
+
+Add support for the new `implicitTags` parameter.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Welcome to [**`@neshca/cache-handler`**](./packages/cache-handler/README.md), a 
 
 ### Next.js Routers support
 
-- Full support for Pages Router.
-- Almost full support for App Router. The only exception is the [`revalidatePath`](https://github.com/caching-tools/next-shared-cache/issues/382) function.
+- Full support for the Pages and the App Router.
 
 ### The importance of shared cache in distributed environments
 

--- a/apps/cache-testing/tests/app.spec.ts
+++ b/apps/cache-testing/tests/app.spec.ts
@@ -37,12 +37,36 @@ test.describe('On-demand revalidation', () => {
     }
 
     for (const path of paths) {
+        test(`If revalidate by path is clicked, then page should be fresh after reload ${path}`, async ({
+            page,
+            baseURL,
+        }) => {
+            const url = new URL(path, `${baseURL}:3000`);
+
+            await page.goto(url.href);
+
+            await refreshPageCache(page, 'path');
+
+            const valueFromPage = Number.parseInt((await page.getByTestId('data').innerText()).valueOf(), 10);
+
+            await refreshPageCache(page, 'path');
+
+            await expect(page.getByTestId('cache-state')).toContainText('fresh');
+
+            const valueFromPageAfterReload = Number.parseInt(
+                (await page.getByTestId('data').innerText()).valueOf(),
+                10,
+            );
+
+            expect(valueFromPageAfterReload - valueFromPage === 1).toBe(true);
+        });
+    }
+
+    for (const path of paths) {
         test(`If revalidate by path is clicked on page A, then page B should be fresh on load ${path}`, async ({
             context,
             baseURL,
         }) => {
-            test.fail(true, 'This test is failing because of revalidate by path is not supported yet.');
-
             const appAUrl = new URL(path, `${baseURL}:3000`);
 
             const appA = await context.newPage();

--- a/docs/cache-handler-docs/src/pages/api-reference/handler.mdx
+++ b/docs/cache-handler-docs/src/pages/api-reference/handler.mdx
@@ -21,6 +21,7 @@ A descriptive name for the cache Handler. This is used to identify the cache Han
 #### Parameters
 
 - `key` - The unique string identifier for the cache entry.
+- `implicitTags` - An array of tags that are implicitly associated with the cache entry.
 
 #### Return value
 

--- a/docs/cache-handler-docs/src/pages/index.mdx
+++ b/docs/cache-handler-docs/src/pages/index.mdx
@@ -2,8 +2,7 @@ Welcome to `@neshca/cache-handler`, a specialized ISR/Data cache API crafted for
 
 ### Next.js Routers support
 
-- Full support for Pages Router.
-- Almost full support for App Router. The only exception is the [`revalidatePath`](https://github.com/caching-tools/next-shared-cache/issues/382) function.
+- Full support for the Pages and the App Router.
 
 ### The importance of shared cache in distributed environments
 

--- a/docs/cache-handler-docs/src/pages/usage/creating-a-custom-handler.mdx
+++ b/docs/cache-handler-docs/src/pages/usage/creating-a-custom-handler.mdx
@@ -18,6 +18,7 @@ Create a file called `cache-handler.mjs` next to your `next.config.js` with the 
 
 ```js filename="cache-handler.mjs" copy
 import { CacheHandler } from '@neshca/cache-handler';
+import { isImplicitTag } from '@neshca/cache-handler/helpers';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import { createClient, commandOptions } from 'redis';
 
@@ -29,6 +30,8 @@ CacheHandler.onCreation(async () => {
 
   // Ignore Redis errors: https://github.com/redis/node-redis?tab=readme-ov-file#events.
   client.on('error', () => {});
+
+  await client.connect();
 
   // Define a timeout for Redis operations.
   const timeoutMs = 1000;
@@ -51,6 +54,8 @@ CacheHandler.onCreation(async () => {
     }
   }
 
+  const revalidatedTagsKey = `${keyPrefix}__revalidated_tags__`;
+
   // Create a custom Redis Handler
   const customRedisHandler = {
     // Give the handler a name.
@@ -58,7 +63,7 @@ CacheHandler.onCreation(async () => {
     name: 'redis-strings-custom',
     // We do not use try/catch blocks in the Handler methods.
     // CacheHandler will handle errors and use the next available Handler.
-    async get(key) {
+    async get(key, implicitTags) {
       // Ensure that the client is ready before using it.
       // If the client is not ready, the CacheHandler will use the next available Handler.
       assertClientIsReady();
@@ -77,7 +82,43 @@ CacheHandler.onCreation(async () => {
       }
 
       // Redis stores strings, so we need to parse the JSON.
-      return JSON.parse(result);
+      const cacheValue = JSON.parse(result);
+
+      // If the cache value has no tags, return it early.
+      if (!cacheValue) {
+        return null;
+      }
+
+      // Get the set of explicit and implicit tags.
+      // implicitTags are available only on the `get` method.
+      const combinedTags = new Set([...cacheValue.tags, ...implicitTags]);
+
+      // If there are no tags, return the cache value early.
+      if (combinedTags.size === 0) {
+        return cacheValue;
+      }
+
+      // Get the revalidation times for the tags.
+      const revalidationTimes = await client.hmGet(
+        commandOptions({ signal: AbortSignal.timeout(timeoutMs) }),
+        revalidatedTagsKey,
+        Array.from(combinedTags),
+      );
+
+      // Iterate over all revalidation times.
+      for (const timeString of revalidationTimes) {
+        // If the revalidation time is greater than the last modified time of the cache value,
+        if (timeString && Number.parseInt(timeString, 10) > cacheValue.lastModified) {
+          // Delete the key from Redis.
+          await client.unlink(commandOptions({ signal: AbortSignal.timeout(timeoutMs) }), keyPrefix + key);
+
+          // Return null to indicate cache miss.
+          return null;
+        }
+      }
+
+      // Return the cache value.
+      return cacheValue;
     },
     async set(key, cacheHandlerValue) {
       // Ensure that the client is ready before using it.
@@ -99,9 +140,7 @@ CacheHandler.onCreation(async () => {
       // If the cache handler value has tags, set the tags.
       // We store them separately to save time to retrieve them in the `revalidateTag` method.
       const setTagsOperation = cacheHandlerValue.tags.length
-        ? client.hSet(options, keyPrefix + sharedTagsKey, {
-            [key]: JSON.stringify(cacheHandlerValue.tags),
-          })
+        ? client.hSet(options, keyPrefix + sharedTagsKey, key, JSON.stringify(cacheHandlerValue.tags))
         : undefined;
 
       // Wait for all operations to complete.
@@ -111,14 +150,46 @@ CacheHandler.onCreation(async () => {
       // Ensure that the client is ready before using it.
       assertClientIsReady();
 
-      // Create a new AbortSignal with a timeout for the Redis operation.
-      const getOptions = commandOptions({ signal: AbortSignal.timeout(timeoutMs) });
+      // Check if the tag is implicit.
+      // Implicit tags are not stored in the cached values.
+      if (isImplicitTag(tag)) {
+        // Mark the tag as revalidated at the current time.
+        await client.hSet(
+          commandOptions({ signal: AbortSignal.timeout(timeoutMs) }),
+          revalidatedTagsKey,
+          tag,
+          Date.now(),
+        );
+      }
 
-      // Get all keys and their tags from Redis from the hash map we've created in the `set` method.
-      const remoteTags = await client.hGetAll(getOptions, keyPrefix + sharedTagsKey);
+      // Create a map to store the tags for each key.
+      const tagsMap = new Map();
 
-      // Create a map from the tags.
-      const tagsMap = new Map(Object.entries(remoteTags));
+      // Cursor for the hScan operation.
+      let cursor = 0;
+
+      // Query size for the hScan operation.
+      const querySize = 25;
+
+      // Iterate over all keys in the shared tags.
+      while (true) {
+        // Get a portion of the keys.
+        const remoteTagsPortion = await client.hScan(keyPrefix + sharedTagsKey, cursor, { COUNT: querySize });
+
+        // Iterate over all keys in the portion.
+        for (const { field, value } of remoteTagsPortion.tuples) {
+          // Parse the tags from the value.
+          tagsMap.set(field, JSON.parse(value));
+        }
+
+        // If the cursor is 0, we have reached the end.
+        if (remoteTagsPortion.cursor === 0) {
+          break;
+        }
+
+        // Update the cursor for the next iteration.
+        cursor = remoteTagsPortion.cursor;
+      }
 
       // Create an array of keys to delete.
       const keysToDelete = [];
@@ -126,12 +197,8 @@ CacheHandler.onCreation(async () => {
       // Create an array of tags to delete form the hash map.
       const tagsToDelete = [];
 
-      // Iterate over all keys and their tags.
-      for (const [key, tagsString] of tagsMap) {
-        // In the set method, we store tags as a stringified array.
-        // So, we need to parse it back to an array.
-        const tags = JSON.parse(tagsString);
-
+      // Iterate over all keys and tags.
+      for (const [key, tags] of tagsMap) {
         // If the tags include the specified tag, add the key to the delete list.
         if (tags.includes(tag)) {
           // Key must be prefixed because we use the key prefix in the set method.

--- a/docs/cache-handler-docs/src/pages/usage/on-demand-revalidation.mdx
+++ b/docs/cache-handler-docs/src/pages/usage/on-demand-revalidation.mdx
@@ -6,12 +6,22 @@ Next.js provides a way to revalidate a page or a result of a `fetch` call on dem
 
 ### Pages Router
 
-The Pages Router supports only the `revalidatePath` option.
+The Pages Router supports only the `response.revalidate(path)`.
 
 See [Using On-Demand Revalidation](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration#using-on-demand-revalidation) in the Next.js documentation.
 
+#### `response.revalidate(path)` caveat
+
+Calling `response.revalidate(path)` will synchronously call `getStaticProps` and render the page with a given `path`. Then it will revalidate the cache for this page. If you want to revalidate multiple paths at once, you need to call `response.revalidate(path)` multiple times.
+
 ### App Router
 
-The App Router supports both `revalidatePath` and `revalidateTag` functions. However due to current limitations, `revalidatePath` is disabled for the App Router.
+The App Router supports both `revalidatePath` and `revalidateTag` functions. These functions will remove the cache values from the store.
 
 See [On-demand Revalidation](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation) in the Next.js documentation.
+
+#### `revalidatePath` caveat
+
+The `revalidatePath` function works differently from the `response.revalidate(path)` and `revalidateTag` functions. It does not revalidate the cached `fetch` result immediately. Instead, it marks the cache as revalidated and the next request will revalidate the cache.
+
+If you are creating a custom cache Handler, you need to manually mark the cache as revalidated in Handler's `revalidateTag` method. Later in the Handler's `get` method, you must check if the cache is revalidated and return `null` if necessary. See [Custom Redis strings example](/usage/creating-a-custom-handler#guide)

--- a/docs/cache-handler-docs/theme.config.jsx
+++ b/docs/cache-handler-docs/theme.config.jsx
@@ -53,10 +53,10 @@ export default {
         ),
     },
     banner: {
-        key: 'version-1.0.0',
+        key: 'version-1.1.0',
         text: (
             <a href="https://nextjs.org/blog/next-14-1">
-                🎉 1.0.0 is out! It features an improved API and TTL by default.
+                🎉 1.1.0 is out! It features Full support for the App Router!
             </a>
         ),
     },

--- a/internal/next-common/src/next-common.ts
+++ b/internal/next-common/src/next-common.ts
@@ -110,3 +110,5 @@ export type TagsManifest = {
     version: 1;
     items: Record<string, { revalidatedAt: number }>;
 };
+
+export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_';

--- a/internal/next-lru-cache/src/create-configured-cache.ts
+++ b/internal/next-lru-cache/src/create-configured-cache.ts
@@ -2,14 +2,20 @@ import { LRUCache } from 'lru-cache';
 
 /**
  * Configuration options for the LRU cache.
+ *
+ * @since 1.0.0
  */
 export type LruCacheOptions = {
     /**
      * Optional. Maximum number of items the cache can hold. Defaults to 1000.
+     *
+     * @since 1.0.0
      */
     maxItemsNumber?: number;
     /**
      * Optional. Maximum size in bytes for each item in the cache. Defaults to 100 MB.
+     *
+     * @since 1.0.0
      */
     maxItemSizeBytes?: number;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3548,9 +3548,9 @@
             ]
         },
         "node_modules/@rushstack/eslint-patch": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.1.tgz",
-            "integrity": "sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz",
+            "integrity": "sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==",
             "dev": true
         },
         "node_modules/@swc/counter": {
@@ -4917,9 +4917,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001607",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-            "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+            "version": "1.0.30001608",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001608.tgz",
+            "integrity": "sha512-cjUJTQkk9fQlJR2s4HMuPMvTiRggl0rAVMtthQuyOlDWuqHXqN8azLq+pi8B2TjwKJ32diHjUqRIKeFX4z1FoA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6236,9 +6236,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.730",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-            "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg==",
+            "version": "1.4.733",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.733.tgz",
+            "integrity": "sha512-gUI9nhI2iBGF0OaYYLKOaOtliFMl+Bt1rY7VmEjwxOxqoYLub/D9xmduPEhbw2imE6gYkJKhIE5it+KE2ulVxQ==",
             "dev": true
         },
         "node_modules/elkjs": {
@@ -7035,9 +7035,9 @@
             }
         },
         "node_modules/eslint-plugin-playwright": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-1.5.4.tgz",
-            "integrity": "sha512-J38Wy3Vc2f9y73J+KRmgXgbYI8TZ3zbz6qBbTj3PhpFndUS572jZ7kqQ3rJ9si5BaMHT7lmZzraO+3UjwIDV4Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-1.6.0.tgz",
+            "integrity": "sha512-tI1E/EDbHT4Fx5KvukUG3RTIT0gk44gvTP8bNwxLCFsUXVM98ZJG5zWU6Om5JOzH9FrmN4AhMu/UKyEsu0ZoDA==",
             "dev": true,
             "workspaces": [
                 "examples"
@@ -7966,9 +7966,9 @@
             "dev": true
         },
         "node_modules/fast-json-stringify": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.14.0.tgz",
-            "integrity": "sha512-6m9a2JN9kDFMADmP9MHLbLPrFu5oSSfrwFLzpcqt/aFgcEi+SVhTJGsx/Wivlls8fQ3OnP8UDNfIY1d1qCC50w==",
+            "version": "5.14.1",
+            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.14.1.tgz",
+            "integrity": "sha512-J1Grbf0oSXV3lKsBf3itz1AvRk43qVrx3Ac10sNvi3LZaz1by4oDdYKFrJycPhS8+Gb7y8rgV/Jqw1UZVjyNvw==",
             "dependencies": {
                 "@fastify/merge-json-schemas": "^0.1.0",
                 "ajv": "^8.10.0",
@@ -10206,9 +10206,9 @@
             }
         },
         "node_modules/light-my-request": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.12.0.tgz",
-            "integrity": "sha512-P526OX6E7aeCIfw/9UyJNsAISfcFETghysaWHQAlQYayynShT08MOj4c6fBCvTWBrHXSvqBAKDp3amUPSCQI4w==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.13.0.tgz",
+            "integrity": "sha512-9IjUN9ZyCS9pTG+KqTDEQo68Sui2lHsYBrfMyVUTTZ3XhH8PMZq7xO94Kr+eP9dhi/kcKsx4N41p2IXEBil1pQ==",
             "dependencies": {
                 "cookie": "^0.6.0",
                 "process-warning": "^3.0.0",
@@ -14628,9 +14628,9 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
-            "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dev": true,
             "dependencies": {
                 "ip-address": "^9.0.5",

--- a/packages/cache-handler/README.md
+++ b/packages/cache-handler/README.md
@@ -2,7 +2,7 @@
 
 **Flexible API to replace the default Next.js cache, accommodating custom cache solutions for multi-instance self-hosted deployments**
 
-🎉 1.0.0 is out! It features an improved API and TTL by default.
+🎉 1.1.0 is out! It features Full support for the App Router!
 
 Check out the [changelog](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/CHANGELOG.md)
 
@@ -26,8 +26,7 @@ Welcome to `@neshca/cache-handler`, a specialized ISR/Data cache API crafted for
 
 ### Next.js Routers support
 
-- Full support for Pages Router.
-- Almost full support for App Router. The only exception is the [`revalidatePath`](https://github.com/caching-tools/next-shared-cache/issues/382) function.
+- Full support for the Pages and the App Router.
 
 ### The importance of shared cache in distributed environments
 

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -4,18 +4,26 @@ export type RedisJSON = Parameters<RedisClientType['json']['set']>['2'];
 
 /**
  * The configuration options for the Redis Handler
+ *
+ * @since 1.0.0
  */
 export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> = {
     /**
      * The Redis client instance.
+     *
+     * @since 1.0.0
      */
     client: T;
     /**
      * Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
+     *
+     * @since 1.0.0
      */
     keyPrefix?: string;
     /**
      * Timeout in milliseconds for Redis operations. Defaults to 5000.
+     *
+     * @since 1.0.0
      */
     timeoutMs?: number;
 };
@@ -23,6 +31,8 @@ export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> 
 export type CreateRedisStringsHandlerOptions = CreateRedisStackHandlerOptions & {
     /**
      * Optional. Key for storing cache tags. Defaults to `__sharedTags__`.
+     *
+     * @since 1.0.0
      */
     sharedTagsKey?: string;
 };

--- a/packages/cache-handler/src/constants.ts
+++ b/packages/cache-handler/src/constants.ts
@@ -1,1 +1,3 @@
 export const MAX_INT32 = 2 ** 31 - 1;
+
+export const REVALIDATED_TAGS_KEY = '__revalidated_tags__';

--- a/packages/cache-handler/src/handlers/server.ts
+++ b/packages/cache-handler/src/handlers/server.ts
@@ -3,10 +3,14 @@ import type { CacheHandlerValue, Handler } from '../cache-handler';
 export type ServerCacheHandlerOptions = {
     /**
      * The base URL of the cache store server.
+     *
+     * @since 1.0.0
      */
     baseUrl: URL | string;
     /**
      * Timeout in milliseconds for remote cache store operations.
+     *
+     * @since 1.0.0
      */
     timeoutMs?: number;
 };
@@ -37,10 +41,11 @@ export type ServerCacheHandlerOptions = {
 export default function createHandler({ baseUrl, timeoutMs }: ServerCacheHandlerOptions): Handler {
     return {
         name: 'server',
-        async get(key) {
+        async get(key, { implicitTags }) {
             const url = new URL('/get', baseUrl);
 
             url.searchParams.set('key', key);
+            url.searchParams.set('implicitTags', JSON.stringify(implicitTags));
 
             const response = await fetch(url, {
                 signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,

--- a/packages/cache-handler/src/helpers/get-tags-from-page-data.ts
+++ b/packages/cache-handler/src/helpers/get-tags-from-page-data.ts
@@ -1,19 +1,5 @@
 import type { IncrementalCachedPageValue } from '@neshca/next-common';
 
-export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_';
-
-/**
- * Checks if a tag is an internal tag.
- * Internal tags start with '\_N_T\_'.
- *
- * @param tag - The tag to check.
- *
- * @returns True if the tag is an internal tag, false otherwise.
- */
-function filterInternalTag(tag: string): boolean {
-    return !tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID);
-}
-
 /**
  * Retrieves the cache tags from the given page data.
  *
@@ -25,5 +11,5 @@ export function getTagsFromPageData(data: IncrementalCachedPageValue): string[] 
     const headers = data.headers?.['x-next-cache-tags'];
     const pageTags = typeof headers === 'string' ? headers.split(',') : [];
 
-    return pageTags.filter(filterInternalTag);
+    return pageTags;
 }

--- a/packages/cache-handler/src/helpers/helpers.ts
+++ b/packages/cache-handler/src/helpers/helpers.ts
@@ -1,1 +1,3 @@
 export { promiseWithTimeout } from './promise-with-timeout';
+export { isImplicitTag } from './is-implicit-tag';
+export { getTimeoutRedisCommandOptions } from './get-timeout-redis-command-options';

--- a/packages/cache-handler/src/helpers/is-implicit-tag.ts
+++ b/packages/cache-handler/src/helpers/is-implicit-tag.ts
@@ -1,0 +1,12 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from '@neshca/next-common';
+
+/**
+ * Checks if a given tag is an implicit tag.
+ *
+ * @param tag - The tag to check.
+ *
+ * @returns A boolean indicating whether the tag is an implicit tag.
+ */
+export function isImplicitTag(tag: string): boolean {
+    return tag.startsWith(NEXT_CACHE_IMPLICIT_TAG_ID);
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,5 +1,10 @@
 {
     "extends": "@repo/typescript-config/library.json",
     "include": ["."],
-    "exclude": ["dist", "node_modules"]
+    "exclude": ["dist", "node_modules"],
+    "compilerOptions": {
+        "paths": {
+            "@neshca/next-common": ["../../internal/next-common/src/next-common.ts"]
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds the `revalidatePath` functionality to the App Router, allowing for on-demand revalidation of pages and fetched data. It also includes updates to the `@neshca/cache-handler` package and its dependencies to support this new feature.

`revalidatePath` was made possible by providing the implicit tags to the Handler's `get` method.

Closes #382