### PR TITLE
Update types, JSDoc, and documentation

### DIFF
--- a/.changeset/fast-ducks-tie.md
+++ b/.changeset/fast-ducks-tie.md
@@ -1,0 +1,22 @@
+---
+'@neshca/cache-handler': patch
+---
+
+Updated types, JSDoc and the documentation.
+
+#### Documentation
+
+- added the documentation for the pre-built `redis-stack`, `redis-strings` and `local-lru` Handlers
+
+#### `@neshca/cache-handle/local-lru`
+
+- marked `LruCacheHandlerOptions` type as deprecated
+- added `LruCacheOptions` export.
+
+#### `@neshca/cache-handle/redis-stack`
+
+- marked `timeoutMs` option as optional
+
+#### `@neshca/cache-handle/redis-strings`
+
+- marked `timeoutMs` option as optional

--- a/apps/cache-testing/cache-handler-redis-stack.mjs
+++ b/apps/cache-testing/cache-handler-redis-stack.mjs
@@ -3,7 +3,6 @@
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-stack';
-import createRedisStringsHandler from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
 CacheHandler.onCreation(async () => {
@@ -11,29 +10,65 @@ CacheHandler.onCreation(async () => {
         console.warn('Make sure that REDIS_URL is added to the .env.local file and loaded properly.');
     }
 
-    const client = createClient({
-        url: process.env.REDIS_URL,
-        name: `cache-handler:${process.env.PORT ?? process.pid}`,
-    });
+    let client;
 
-    client.on('error', () => {});
+    try {
+        // Create a Redis client.
+        client = createClient({
+            url: process.env.REDIS_URL,
+            name: `cache-handler:${process.env.PORT ?? process.pid}`,
+        });
 
-    console.info('Connecting Redis client...');
-    await client.connect();
-    console.info('Redis client connected.');
+        // Redis won't work without error handling.
+        client.on('error', () => {});
+    } catch (error) {
+        console.warn('Failed to create Redis client:', error);
+    }
 
-    const redisHandler = await createRedisHandler({
-        client,
-        keyPrefix: 'JSON:',
-        timeoutMs: 1000,
-    });
+    if (client) {
+        try {
+            console.info('Connecting Redis client...');
 
-    const redisStringsHandler = createRedisStringsHandler({ client, keyPrefix: 'strings:', timeoutMs: 1000 });
+            // Wait for the client to connect.
+            // Caveat: This will block the server from starting until the client is connected.
+            // And there is no timeout. Make your own timeout if needed.
+            await client.connect();
+            console.info('Redis client connected.');
+        } catch (error) {
+            console.warn('Failed to connect Redis client:', error);
 
-    const localHandler = createLruHandler();
+            console.warn('Disconnecting the Redis client...');
+            // Try to disconnect the client to stop it from reconnecting.
+            client
+                .disconnect()
+                .then(() => {
+                    console.info('Redis client disconnected.');
+                })
+                .catch(() => {
+                    console.warn('Failed to quit the Redis client after failing to connect.');
+                });
+        }
+    }
+
+    /** @type {import("@neshca/cache-handler").Handler | null} */
+    let handler;
+
+    if (client?.isReady) {
+        // Create the `redis-stack` Handler if the client is available and connected.
+        handler = await createRedisHandler({
+            client,
+            keyPrefix: 'JSON:',
+            timeoutMs: 1000,
+        });
+    } else {
+        // Fallback to LRU handler if Redis client is not available.
+        // The application will still work, but the cache will be in-memory only and not shared.
+        handler = createLruHandler();
+        console.warn('Falling back to LRU handler because Redis client is not available.');
+    }
 
     return {
-        handlers: [redisHandler, redisStringsHandler, localHandler],
+        handlers: [handler],
         ttl: { defaultStaleAge: 60, estimateExpireAge: (staleAge) => staleAge * 2 },
     };
 });

--- a/docs/cache-handler-docs/src/pages/_meta.json
+++ b/docs/cache-handler-docs/src/pages/_meta.json
@@ -11,6 +11,7 @@
     },
     "configuration": "Configuration",
     "api-reference": "API reference",
+    "handlers": "Handlers",
     "functions": "Functions",
     "-- Usage": {
         "type": "separator",

--- a/docs/cache-handler-docs/src/pages/handlers/_meta.json
+++ b/docs/cache-handler-docs/src/pages/handlers/_meta.json
@@ -1,0 +1,5 @@
+{
+    "redis-stack": "redis-stack",
+    "redis-strings": "redis-strings",
+    "local-lru": "local-lru"
+}

--- a/docs/cache-handler-docs/src/pages/handlers/local-lru.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/local-lru.mdx
@@ -1,0 +1,35 @@
+import { Callout } from 'nextra/components';
+
+# `local-lru` Handler
+
+```js
+import createLocalHandler from '@neshca/cache-handler/local-lru';
+
+// ...
+const localHandler = createLocalHandler({
+  maxItemsNumber: 10000,
+  maxItemSizeBytes: 1024 * 1024 * 500,
+});
+// ...
+```
+
+The `local-lru` Handler uses a [`lru-cache`](https://www.npmjs.com/package/lru-cache) instance as the cache store. It stores the cache in memory and evicts the least recently used entries when the cache reaches its limits. You can use this Handler as a fallback cache when the shared cache is unavailable.
+
+<Callout type="info">
+  The `local-lru` Handler stores the cache in memory. Make sure to set the limits according to your server's memory
+  capacity.
+</Callout>
+
+## API
+
+`@neshca/cache-handler/local-lru` exports a function that creates a new `Handler` instance for the `local-lru` Handler.
+
+### Parameters
+
+- `options` - An object containing the following properties:
+  - `maxItemsNumber` - Optional. Maximum number of items the cache can hold. Defaults to `1000`.
+  - `maxItemSizeBytes` - Optional. Maximum size in bytes for each item in the cache. Defaults to `1024 * 1024 * 100` (100 MB).
+
+### Return value
+
+A new `Handler` instance for the `local-lru` Handler.

--- a/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
@@ -1,0 +1,38 @@
+import { Callout } from 'nextra/components';
+
+# `redis-stack` Handler
+
+```js
+import createRedisHandler from '@neshca/cache-handler/redis-stack';
+
+// ...
+await client.connect();
+
+const redisHandler = await createRedisHandler({
+  client,
+  keyPrefix: 'prefix:',
+  timeoutMs: 1000,
+});
+// ...
+```
+
+The `redis-stack` Handler uses Redis with `RedisJSON` and `RedisSearch` modules as the cache store. It is a full-featured cache handler that supports JSON objects and full-text search, offering a trade-off between performance and flexibility. While it may sacrifice some speed compared to the [`redis-strings`](/handlers/redis-strings) Handler, it empowers you to manage cache on demand more efficiently and faster. It also allows for more versatile cache usage from your application, such as creating custom revalidating strategies and functions. The `redis-stack` Handler is suitable for applications that require advanced cache management and search capabilities.
+
+<Callout type="info">
+  Make sure that you have the `RedisJSON` and `RedisSearch` modules installed and enabled in your Redis server.
+</Callout>
+
+## API
+
+`@neshca/cache-handler/redis-stack` exports a function that creates a new `Handler` instance for the `redis-stack` Handler.
+
+### Parameters
+
+- `options` - An object containing the following properties:
+  - `client` - A Redis client instance. The client must be ready before creating the Handler.
+  - `keyPrefix` - Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
+  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
+
+### Return value
+
+A Promise that resolves to a new `Handler` instance for the `redis-stack` Handler.

--- a/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
@@ -1,0 +1,41 @@
+# `redis-strings` Handler
+
+```js
+import createRedisHandler from '@neshca/cache-handler/redis-strings';
+
+// ...
+await client.connect();
+
+const redisHandler = createRedisHandler({
+  client,
+  keyPrefix: 'JSON:',
+  timeoutMs: 1000,
+  keyExpirationStrategy: 'EXAT',
+  sharedTagsKey: '__sharedTags__',
+});
+// ...
+```
+
+The `redis-strings` Handler uses plain Redis as the cache store. It is a simple and fast cache handler that is suitable for most applications. This Handler is ideal for applications that require fast and efficient cache management without the need for advanced features like full-text search for custom revalidation strategies.
+
+## API
+
+`@neshca/cache-handler/redis-strings` exports a function that creates a new `Handler` instance for the `redis-strings` Handler.
+
+### Parameters
+
+- `options` - An object containing the following properties:
+  - `client` - A Redis client instance. The client must be ready before creating the Handler.
+  - `keyPrefix` - Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
+  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
+  - `keyExpirationStrategy` - Optional. It allows you to choose the expiration strategy for cache keys. Defaults to `EXPRIREAT`.
+  - `sharedTagsKey` - Optional. Dedicated key for the internal revalidation process. It must not interfere with cache keys from your application. Defaults to `__sharedTags__`.
+
+#### `keyExpirationStrategy`
+
+- `'EXAT'`: Uses the `EXAT` option of the `SET` command to set the expiration time. This is more efficient than `EXPIREAT`. Requires Redis server 6.2.0 or newer
+- `'EXPIREAT'`: Uses the `EXPIREAT` command to set the expiration time. This requires an additional command call. Requires Redis server 4.0.0 or newer.
+
+### Return value
+
+A new `Handler` instance for the `redis-strings` Handler.

--- a/docs/cache-handler-docs/src/pages/redis.mdx
+++ b/docs/cache-handler-docs/src/pages/redis.mdx
@@ -1,11 +1,13 @@
 import { Callout } from 'nextra/components';
 
-## Redis Stack example
+## `redis-stack` Handler example
 
 <Callout type="info">
   In this example, we assume that in your deployment, you have `REDIS_URL` environment variable set to the URL of your
   Redis instance. You can use any other way to set the URL.
 </Callout>
+
+See the [`redis-stack` Handler](/handlers/redis-stack) documentation for more information and requirements for the Redis server.
 
 Create a file called `cache-handler.mjs` next to your `next.config.js` with the following contents:
 
@@ -13,31 +15,67 @@ Create a file called `cache-handler.mjs` next to your `next.config.js` with the 
 import { CacheHandler } from '@neshca/cache-handler';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-stack';
-// or if you are using Redis without the RedisJSON module
-// import createRedisHandler from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
 CacheHandler.onCreation(async () => {
-  // always create a Redis client inside the `onCreation` callback
-  const client = createClient({
-    url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-  });
+  let client;
 
-  client.on('error', () => {});
+  try {
+    // Create a Redis client.
+    client = createClient({
+      url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+    });
 
-  await client.connect();
+    // Redis won't work without error handling.
+    client.on('error', () => {});
+  } catch (error) {
+    console.warn('Failed to create Redis client:', error);
+  }
 
-  const redisHandler = await createRedisHandler({
-    client,
-    // timeout for the Redis client operations like `get` and `set`
-    // after this timeout, the operation will be considered failed and the `localHandler` will be used
-    timeoutMs: 5000,
-  });
+  if (client) {
+    try {
+      console.info('Connecting Redis client...');
 
-  const localHandler = createLruHandler();
+      // Wait for the client to connect.
+      // Caveat: This will block the server from starting until the client is connected.
+      // And there is no timeout. Make your own timeout if needed.
+      await client.connect();
+      console.info('Redis client connected.');
+    } catch (error) {
+      console.warn('Failed to connect Redis client:', error);
+
+      console.warn('Disconnecting the Redis client...');
+      // Try to disconnect the client to stop it from reconnecting.
+      client
+        .disconnect()
+        .then(() => {
+          console.info('Redis client disconnected.');
+        })
+        .catch(() => {
+          console.warn('Failed to quit the Redis client after failing to connect.');
+        });
+    }
+  }
+
+  /** @type {import("@neshca/cache-handler").Handler | null} */
+  let handler;
+
+  if (client?.isReady) {
+    // Create the `redis-stack` Handler if the client is available and connected.
+    handler = await createRedisHandler({
+      client,
+      keyPrefix: 'prefix:',
+      timeoutMs: 1000,
+    });
+  } else {
+    // Fallback to LRU handler if Redis client is not available.
+    // The application will still work, but the cache will be in memory only and not shared.
+    handler = createLruHandler();
+    console.warn('Falling back to LRU handler because Redis client is not available.');
+  }
 
   return {
-    handlers: [redisHandler, localHandler],
+    handlers: [handler],
   };
 });
 

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -23,7 +23,7 @@ export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> 
      */
     keyPrefix?: string;
     /**
-     * Timeout in milliseconds for Redis operations.
+     * Optional. Timeout in milliseconds for Redis operations.
      *
      * @default 5000 // 5000 ms
      *

--- a/packages/cache-handler/src/handlers/local-lru.ts
+++ b/packages/cache-handler/src/handlers/local-lru.ts
@@ -4,7 +4,12 @@ import createCacheStore from '@neshca/next-lru-cache/next-cache-handler-value';
 import { NEXT_CACHE_IMPLICIT_TAG_ID } from '@neshca/next-common';
 import type { Handler } from '../cache-handler';
 
+/**
+ * @deprecated Use {@link LruCacheOptions} instead.
+ */
 export type LruCacheHandlerOptions = LruCacheOptions;
+
+export type { LruCacheOptions };
 
 /**
  * Creates an LRU (Least Recently Used) cache Handler.
@@ -14,7 +19,7 @@ export type LruCacheHandlerOptions = LruCacheOptions;
  * The handler includes methods to get and set cache values.
  * Revalidation is handled by the `CacheHandler` class.
  *
- * @param options - The configuration options for the LRU cache handler. See {@link LruCacheHandlerOptions}.
+ * @param options - The configuration options for the LRU cache handler. See {@link LruCacheOptions}.
  *
  * @returns An object representing the cache, with methods for cache operations.
  *
@@ -31,7 +36,7 @@ export type LruCacheHandlerOptions = LruCacheOptions;
  *
  * @since 1.0.0
  */
-export default function createHandler({ ...lruOptions }: LruCacheHandlerOptions = {}): Handler {
+export default function createHandler({ ...lruOptions }: LruCacheOptions = {}): Handler {
     const lruCacheStore = createCacheStore(lruOptions);
 
     const revalidatedTags = new Map<string, number>();


### PR DESCRIPTION
This pull request updates the types, JSDoc, and documentation for the cache handlers. It includes the following changes:

- Added documentation for the pre-built `redis-stack`, `redis-strings`, and `local-lru` handlers.

- Marked `LruCacheHandlerOptions` type as deprecated and added `LruCacheOptions` export.

- Marked `timeoutMs` option as optional in the `@neshca/cache-handle/redis-stack` and `@neshca/cache-handle/redis-strings` handlers.