### PR TITLE
Update GitHub Actions workflows to run only on specific paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,9 @@ name: Deploy docs to Pages
 on:
   push:
     branches: ['canary']
+    paths:
+      - 'docs/cache-handler-docs/**'
+      - '.github/workflows/deploy-docs.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,22 @@ name: Tests
 on:
   push:
     branches: [canary]
+    paths:
+      - 'apps/cache-testing/**'
+      - 'packages/cache-handler/**'
+      - 'internal/next-common/**'
+      - 'internal/next-lru-cache/**'
+      - 'server/**'
+      - '.github/workflows/tests.yml'
   pull_request:
     branches: [canary]
+    paths:
+      - 'apps/cache-testing/**'
+      - 'packages/cache-handler/**'
+      - 'internal/next-common/**'
+      - 'internal/next-lru-cache/**'
+      - 'server/**'
+      - '.github/workflows/tests.yml'
 jobs:
   test:
     name: 'redis-stack'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to run only on specific paths. This ensures that the workflows are triggered only when changes are made to the specified files and directories, improving efficiency and reducing unnecessary workflow runs.