### PR TITLE
Add the new option `revalidateTagQuerySize` to the `redis-stack` and the `redis-strings` Handlers

### DIFF
--- a/.changeset/tricky-kids-end.md
+++ b/.changeset/tricky-kids-end.md
@@ -1,0 +1,15 @@
+---
+'@neshca/cache-handler': minor
+---
+
+#### New Features
+
+##### `@neshca/cache-handle/redis-strings`
+
+- Added `revalidateTagQuerySize` option. It allows specifying the number of tags in a single query retrieved from Redis when scanning or searching for tags.
+- Increased the default query size for `hScan` from 25 to 100.
+
+##### `@neshca/cache-handle/redis-stack`
+
+- Added `revalidateTagQuerySize` option. It allows specifying the number of tags in a single query retrieved from Redis when scanning or searching for tags.
+- Increased the default query size for `ft.search` from 25 to 100.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,15 @@ on:
       - '.prettierrc.json'
 jobs:
   test:
-    name: 'redis-stack'
+    strategy:
+      max-parallel: 2
+      matrix:
+        handler: [redis-stack, redis-strings]
+    name: ${{ matrix.handler }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      HANDLER_PATH: ./cache-handler-redis-stack.mjs
+      HANDLER_PATH: ./cache-handler-${{ matrix.handler }}.mjs
       REDIS_URL: redis://localhost:6379
     services:
       redis:
@@ -73,6 +77,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.handler }}
           path: apps/cache-testing/playwright-report/
           retention-days: 7

--- a/apps/cache-testing/cache-handler-redis-strings.mjs
+++ b/apps/cache-testing/cache-handler-redis-strings.mjs
@@ -1,7 +1,6 @@
 // @ts-check
 
 import { CacheHandler } from '@neshca/cache-handler';
-import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
@@ -29,10 +28,9 @@ CacheHandler.onCreation(async () => {
         keyPrefix: PREFIX,
     });
 
-    const localHandler = createLruHandler();
-
     return {
-        handlers: [redisHandler, localHandler],
+        handlers: [redisHandler],
+        ttl: { defaultStaleAge: 60, estimateExpireAge: (staleAge) => staleAge * 2 },
     };
 });
 

--- a/apps/cache-testing/playwright.config.ts
+++ b/apps/cache-testing/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     testDir: './tests',
     fullyParallel: false,
     forbidOnly: Boolean(process.env.CI),
-    retries: process.env.CI ? 1 : 0,
+    retries: 0,
     workers: 1,
     reporter: 'html',
     use: { baseURL: 'http://localhost', trace: 'on-first-retry', testIdAttribute: 'data-pw' },

--- a/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
@@ -12,6 +12,7 @@ const redisHandler = await createRedisHandler({
   client,
   keyPrefix: 'prefix:',
   timeoutMs: 1000,
+  revalidateTagQuerySize: 100,
 });
 // ...
 ```
@@ -32,6 +33,11 @@ The `redis-stack` Handler uses Redis with `RedisJSON` and `RedisSearch` modules 
   - `client` - A Redis client instance. The client must be ready before creating the Handler.
   - `keyPrefix` - Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
   - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
+  - `revalidateTagQuerySize` - Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags. Defaults to `100`.
+
+#### `revalidateTagQuerySize`
+
+You can adjust this value to optimize the number of commands sent to Redis when scanning or searching for tags. A higher value will reduce the number of commands sent to Redis, but it will also increase the amount of data transferred over the network. Redis uses TCP and typically has 65,535 bytes as the maximum size of a packet (it can be lower depending on MTU).
 
 ### Return value
 

--- a/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
@@ -12,6 +12,7 @@ const redisHandler = createRedisHandler({
   timeoutMs: 1000,
   keyExpirationStrategy: 'EXAT',
   sharedTagsKey: '__sharedTags__',
+  revalidateTagQuerySize: 100,
 });
 // ...
 ```
@@ -30,11 +31,16 @@ The `redis-strings` Handler uses plain Redis as the cache store. It is a simple 
   - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
   - `keyExpirationStrategy` - Optional. It allows you to choose the expiration strategy for cache keys. Defaults to `EXPRIREAT`.
   - `sharedTagsKey` - Optional. Dedicated key for the internal revalidation process. It must not interfere with cache keys from your application. Defaults to `__sharedTags__`.
+  - `revalidateTagQuerySize` - Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags. Defaults to `100`.
 
 #### `keyExpirationStrategy`
 
 - `'EXAT'`: Uses the `EXAT` option of the `SET` command to set the expiration time. This is more efficient than `EXPIREAT`. Requires Redis server 6.2.0 or newer
 - `'EXPIREAT'`: Uses the `EXPIREAT` command to set the expiration time. This requires an additional command call. Requires Redis server 4.0.0 or newer.
+
+#### `revalidateTagQuerySize`
+
+You can adjust this value to optimize the number of commands sent to Redis when scanning or searching for tags. A higher value will reduce the number of commands sent to Redis, but it will also increase the amount of data transferred over the network. Redis uses TCP and typically has 65,535 bytes as the maximum size of a packet (it can be lower depending on MTU).
 
 ### Return value
 

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -30,6 +30,20 @@ export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> 
      * @since 1.0.0
      */
     timeoutMs?: number;
+    /**
+     * Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags.
+     *
+     * @default 100 // 100 tags
+     *
+     * @since 1.4.0
+     *
+     * @remarks
+     * You can adjust this value to optimize the number of commands sent to Redis when scanning or searching for tags.
+     * A higher value will reduce the number of commands sent to Redis,
+     * but it will also increase the amount of data transferred over the network.
+     * Redis uses TCP and typically has 65,535 bytes as the maximum size of a packet (it can be lower depending on MTU).
+     */
+    revalidateTagQuerySize?: number;
 };
 
 export type CreateRedisStringsHandlerOptions = CreateRedisStackHandlerOptions & {


### PR DESCRIPTION
This pull request adds the new option `revalidateTagQuerySize` to the `redis-stack` and `redis-strings` Handlers. The `revalidateTagQuerySize` option allows specifying the number of tags in a single query retrieved from Redis when scanning or searching for tags. The default query size for `hScan` in `redis-stack` and `ft.search` in `redis-strings` has also been increased from 25 to 100. Adjusting this value can optimize the number of commands sent to Redis, reducing the number of commands at the cost of increased TCP packet size.