### PR TITLE
redis-stack: revalidateTag shouldn't fetch cache content

### DIFF
--- a/packages/cache-handler/src/handlers/redis-stack.ts
+++ b/packages/cache-handler/src/handlers/redis-stack.ts
@@ -146,7 +146,7 @@ export default async function createHandler({
             const keysToDelete: string[] = [];
 
             while (true) {
-                const { documents } = await client.ft.search(
+                const { documents: documentIds } = await client.ft.searchNoContent(
                     getTimeoutRedisCommandOptions(timeoutMs),
                     'idx:tags',
                     `@tag:(${sanitizedTag})`,
@@ -156,11 +156,11 @@ export default async function createHandler({
                     },
                 );
 
-                for (const { id } of documents) {
+                for (const id of documentIds) {
                     keysToDelete.push(id);
                 }
 
-                if (documents.length < revalidateTagQuerySize) {
+                if (documentIds.length < revalidateTagQuerySize) {
                     break;
                 }
 


### PR DESCRIPTION
Fetching the whole document causes high memory usage and sometimes causes OOM crashes.
Fixes #636