### PR TITLE
Add ability to disable Redis operations timeout

### DIFF
--- a/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
@@ -32,7 +32,7 @@ The `redis-stack` Handler uses Redis with `RedisJSON` and `RedisSearch` modules 
 - `options` - An object containing the following properties:
   - `client` - A Redis client instance. The client must be ready before creating the Handler.
   - `keyPrefix` - Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
-  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
+  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`. For disabling timeouts, set it to `0`.
   - `revalidateTagQuerySize` - Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags. Defaults to `100`.
 
 #### `revalidateTagQuerySize`

--- a/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-strings.mdx
@@ -28,7 +28,7 @@ The `redis-strings` Handler uses plain Redis as the cache store. It is a simple 
 - `options` - An object containing the following properties:
   - `client` - A Redis client instance. The client must be ready before creating the Handler.
   - `keyPrefix` - Optional. Prefix for all keys, useful for namespacing. Defaults to an empty string.
-  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`.
+  - `timeoutMs` - Optional. Timeout in milliseconds for Redis operations. Defaults to `5000`. For disabling timeouts, set it to `0`.
   - `keyExpirationStrategy` - Optional. It allows you to choose the expiration strategy for cache keys. Defaults to `EXPRIREAT`.
   - `sharedTagsKey` - Optional. Dedicated key for the internal revalidation process. It must not interfere with cache keys from your application. Defaults to `__sharedTags__`.
   - `revalidateTagQuerySize` - Optional. The number of tags in a single query retrieved from Redis when scanning or searching for tags. Defaults to `100`.

--- a/packages/cache-handler/src/common-types.ts
+++ b/packages/cache-handler/src/common-types.ts
@@ -28,6 +28,9 @@ export type CreateRedisStackHandlerOptions<T = ReturnType<typeof createClient>> 
      * @default 5000 // 5000 ms
      *
      * @since 1.0.0
+     *
+     * @remarks
+     * To disable timeout of Redis operations, set this option to 0.
      */
     timeoutMs?: number;
     /**

--- a/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
+++ b/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
@@ -3,5 +3,9 @@ import { commandOptions } from 'redis';
 type CommandOptions = ReturnType<typeof commandOptions>;
 
 export function getTimeoutRedisCommandOptions(timeoutMs: number): CommandOptions {
-    return commandOptions(!!timeoutMs && timeoutMs !== 0 ? { signal: AbortSignal.timeout(timeoutMs) } : {});
+    if (timeoutMs === 0) {
+        return commandOptions({});
+    }
+
+    return commandOptions({ signal: AbortSignal.timeout(timeoutMs) });
 }

--- a/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
+++ b/packages/cache-handler/src/helpers/get-timeout-redis-command-options.ts
@@ -3,5 +3,5 @@ import { commandOptions } from 'redis';
 type CommandOptions = ReturnType<typeof commandOptions>;
 
 export function getTimeoutRedisCommandOptions(timeoutMs: number): CommandOptions {
-    return commandOptions({ signal: AbortSignal.timeout(timeoutMs) });
+    return commandOptions(!!timeoutMs && timeoutMs !== 0 ? { signal: AbortSignal.timeout(timeoutMs) } : {});
 }


### PR DESCRIPTION
There is a known bug in the Redis package, that will be fixed in version 5, which is in the alpha stage. (https://github.com/redis/node-redis/issues/2498)

The issue is about the usage of AbortSignal. When it is used, if the Redis connection encounters an error, like the Redis server gets offline, an unhandled error will be thrown. This error will cause an issue with the reconnection of the client, and it'll put the Redis client into a limbo stage that will not recover unless the Next.js app restarts.

This PR will address this issue by giving the ability to disable the Redis operations timeout totally, by setting the value of `timeoutMS: 0` for `redis-string` and `redis-stacks` handlers.