### PR TITLE
Update creating-a-custom-handler.mdx

### DIFF
--- a/docs/cache-handler-docs/src/pages/usage/creating-a-custom-handler.mdx
+++ b/docs/cache-handler-docs/src/pages/usage/creating-a-custom-handler.mdx
@@ -222,7 +222,7 @@ CacheHandler.onCreation(async () => {
       // Update the tags in Redis by deleting the revalidated tags.
       const updateTagsOperation = client.hDel(
         // Use the isolated option to prevent the command from being executed on the main connection.
-        { isolated: true, ...getTimeoutRedisCommandOptions(timeoutMs) },
+        { isolated: true, ...commandOptions({ signal: AbortSignal.timeout(timeoutMs) }) },
         keyPrefix + sharedTagsKey,
         tagsToDelete,
       );


### PR DESCRIPTION
Fix function not found: Replace getTimeoutRedisCommandOptions to commandOptions({ signal: AbortSignal.timeout(timeoutMs)