### PR TITLE
Refactor search index creation in the `redis-stack` Handler

### DIFF
--- a/.changeset/slimy-suns-melt.md
+++ b/.changeset/slimy-suns-melt.md
@@ -1,0 +1,13 @@
+---
+'@neshca/cache-handler': minor
+---
+
+Refactor search index creation in the `redis-stack` Handler
+
+#### Minor Changes
+
+##### `@neshca/cache-handler/redis-stack`
+
+- Move search index creation to revalidateTag method:
+  - Ensure index existence before searching by creating it inside revalidateTag with a randomized name to avoid collisions
+  - Allow synchronous Handler creation without waiting for the client to connect

--- a/apps/cache-testing/cache-handler-redis-stack.mjs
+++ b/apps/cache-testing/cache-handler-redis-stack.mjs
@@ -57,9 +57,9 @@ CacheHandler.onCreation(async () => {
     /** @type {import("@neshca/cache-handler").Handler | null} */
     let handler;
 
-    if (client?.isReady) {
-        // Create the `redis-stack` Handler if the client is available and connected.
-        handler = await createRedisHandler({
+    if (client) {
+        // Create the `redis-stack` Handler if the client is available.
+        handler = createRedisHandler({
             client,
             keyPrefix: 'JSON:',
             timeoutMs: 1000,

--- a/apps/cache-testing/next.config.mjs
+++ b/apps/cache-testing/next.config.mjs
@@ -1,6 +1,8 @@
-const path = require('node:path');
+// @ts-check
 
-const cacheHandler = require.resolve(process.env.HANDLER_PATH ?? './cache-handler-redis-stack.mjs');
+import path from 'node:path';
+
+const cacheHandler = path.resolve(process.env.HANDLER_PATH ?? './cache-handler-redis-stack.mjs');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -13,8 +15,8 @@ const nextConfig = {
         // PPR should only be configured via the PPR_ENABLED env variable due to conditional logic in tests.
         ppr: process.env.PPR_ENABLED === 'true',
         largePageDataBytes: 1024 * 1024, // 1MB
-        outputFileTracingRoot: path.join(__dirname, '../../'),
+        outputFileTracingRoot: path.join(import.meta.dirname, '../../'),
     },
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
+++ b/docs/cache-handler-docs/src/pages/handlers/redis-stack.mdx
@@ -9,7 +9,7 @@ import createRedisHandler from '@neshca/cache-handler/redis-stack';
 const client = createClient(clientOptions);
 await client.connect();
 
-const redisHandler = await createRedisHandler({
+const redisHandler = createRedisHandler({
   client,
   keyPrefix: 'prefix:',
   timeoutMs: 1000,
@@ -41,4 +41,4 @@ You can adjust this value to optimize the number of commands sent to Redis when 
 
 ### Return value
 
-A Promise that resolves to a new `Handler` instance for the `redis-stack` Handler.
+A new `Handler` instance for the `redis-stack` Handler.

--- a/internal/next-common/package.json
+++ b/internal/next-common/package.json
@@ -11,7 +11,7 @@
         "clean": "rimraf ./.turbo ./node_modules"
     },
     "dependencies": {
-        "next": "14.2.0-canary.61"
+        "next": "14.3.0-canary.44"
     },
     "devDependencies": {
         "@repo/typescript-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,7 +587,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "next": "14.2.0-canary.61"
+                "next": "14.3.0-canary.44"
             },
             "devDependencies": {
                 "@repo/typescript-config": "*",
@@ -596,162 +596,14 @@
                 "typescript": "5.5.4"
             }
         },
-        "internal/next-common/node_modules/@next/env": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.0-canary.61.tgz",
-            "integrity": "sha512-Ueqse8kdwaoebGrpSo60M4/cjFaMJEE7BMsKZufYwZDTlE0qXw7N4GsdVpUZzJG00sXf6CoTnCU1lCTPrUMC4g=="
-        },
-        "internal/next-common/node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.0-canary.61.tgz",
-            "integrity": "sha512-mMlp2/hvtaBbCY5qYhuvAqX9Z/aFC+Rgme4FjFSxq2C3TC/mL3G4fVG/TVl7bqjikKCxSvJgiWXRwvhIaqGktw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.0-canary.61.tgz",
-            "integrity": "sha512-4bEjO0WK6keRi972eAY1AfvTXOQRHnM59klNqnUh5zfalbi7VkEdluhYAZOop2NycCHjF+m8p+ytYtrF1uCO1Q==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.0-canary.61.tgz",
-            "integrity": "sha512-wIXc3EdxrETlL2XwlGlLQkMU9godhNSMAXxiJotd/mhN3K4iKajPahAStvFxY2Zwc/on2IBa0NpUGpzDONNt9A==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.0-canary.61.tgz",
-            "integrity": "sha512-95aMF55sq2N6+5iLEqxCfz7ccYMBURQ8D0KYmcq+rMJTE5z/qvxEToSJWAbV4jGyd2Eq/vXjPdR1rFytv2FnOw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.0-canary.61.tgz",
-            "integrity": "sha512-LWG5OC9hNSCYtDb+7MQcIjE1PO70Sho+ZJkqJnmLxJ08Atp/nJQBo9nAMjORdcO5Nz+hPNVY5vmrY+5Fl5kadw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.0-canary.61.tgz",
-            "integrity": "sha512-EjOXbSmDTPVi8xkOix4/WYJM6OUert+lfBtdUJBRba+oGiRw/mheih8FliFZKFOmQbPYj67A9z/QCus2ZDnfSw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.0-canary.61.tgz",
-            "integrity": "sha512-TK8oV4ozzUGWAwvZp/0SBsNgAUhrUFLWCMSXsFHz+YMRjHg7nT0KdK8BYh2Ln4Qt0jjDTUHbI1jaQKxmSMEMmA==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.0-canary.61.tgz",
-            "integrity": "sha512-i0iWCehuLKDOfVbQ6MEKG9v0lfcJU0DPWkYINFSi6p3fkFobI/+7DVT3KvYH5VVng/+opx+pA6cesV5eyQnBtw==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.0-canary.61.tgz",
-            "integrity": "sha512-WB0UjpWcu+oXQOMFDTHDZWKcL2jiXeQfN+1RRkb0x7ZjVxvA/O66vOJE08fLSu7rdymLiGXxX+AKlGFq1Tpisg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "internal/next-common/node_modules/@swc/helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-            "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "tslib": "^2.4.0"
-            }
-        },
         "internal/next-common/node_modules/next": {
-            "version": "14.2.0-canary.61",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.0-canary.61.tgz",
-            "integrity": "sha512-UbdoNkGX04TO0Q0N3k7fmiNCliE1yihVBHd/nwg2zMnpjB6dGU3r1UNgCBpfUUlrs1t19FAWazfVQANOOfBT4w==",
+            "version": "14.3.0-canary.44",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.3.0-canary.44.tgz",
+            "integrity": "sha512-iYJmuiARcldXjN27N0Yo8gWyy6vWl+FoUNcEaL2GGh3sA/rc4hcbZD89ZUXoVFsPAI7ze6sKM60Znct9RwCbKQ==",
+            "license": "MIT",
             "dependencies": {
-                "@next/env": "14.2.0-canary.61",
-                "@swc/helpers": "0.5.5",
+                "@next/env": "14.3.0-canary.44",
+                "@swc/helpers": "0.5.11",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",
@@ -765,15 +617,16 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.0-canary.61",
-                "@next/swc-darwin-x64": "14.2.0-canary.61",
-                "@next/swc-linux-arm64-gnu": "14.2.0-canary.61",
-                "@next/swc-linux-arm64-musl": "14.2.0-canary.61",
-                "@next/swc-linux-x64-gnu": "14.2.0-canary.61",
-                "@next/swc-linux-x64-musl": "14.2.0-canary.61",
-                "@next/swc-win32-arm64-msvc": "14.2.0-canary.61",
-                "@next/swc-win32-ia32-msvc": "14.2.0-canary.61",
-                "@next/swc-win32-x64-msvc": "14.2.0-canary.61"
+                "@next/swc-darwin-arm64": "14.3.0-canary.44",
+                "@next/swc-darwin-x64": "14.3.0-canary.44",
+                "@next/swc-linux-arm64-gnu": "14.3.0-canary.44",
+                "@next/swc-linux-arm64-musl": "14.3.0-canary.44",
+                "@next/swc-linux-x64-gnu": "14.3.0-canary.44",
+                "@next/swc-linux-x64-musl": "14.3.0-canary.44",
+                "@next/swc-win32-arm64-msvc": "14.3.0-canary.44",
+                "@next/swc-win32-ia32-msvc": "14.3.0-canary.44",
+                "@next/swc-win32-x64-msvc": "14.3.0-canary.44",
+                "sharp": "^0.33.3"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",

--- a/packages/cache-handler/src/constants.ts
+++ b/packages/cache-handler/src/constants.ts
@@ -1,3 +1,5 @@
 export const MAX_INT32 = 2 ** 31 - 1;
 
+export const TIME_ONE_YEAR = 31536000;
+
 export const REVALIDATED_TAGS_KEY = '__revalidated_tags__';

--- a/packages/cache-handler/src/functions/nesh-cache.ts
+++ b/packages/cache-handler/src/functions/nesh-cache.ts
@@ -6,8 +6,7 @@ import {
     type StaticGenerationStore,
     staticGenerationAsyncStorage,
 } from '@neshca/next-common';
-
-const CACHE_ONE_YEAR = 31536000;
+import { TIME_ONE_YEAR } from '../constants';
 
 function getDerivedTags(pathname: string): string[] {
     const derivedTags: string[] = ['/layout'];
@@ -322,7 +321,7 @@ export function neshCache<Arguments extends unknown[], Result extends Promise<un
                     headers: {},
                     url: 'neshCache',
                 },
-                revalidate: revalidate || CACHE_ONE_YEAR,
+                revalidate: revalidate || TIME_ONE_YEAR,
             },
             { revalidate, tags, fetchCache: true, fetchIdx, fetchUrl: 'neshCache' },
         );


### PR DESCRIPTION
In this PR:

- Move search index creation to `revalidateTag` method:
  - Ensure index existence before searching by creating it inside `revalidateTag` with a randomized name to avoid collisions
  - Allow synchronous Handler creation without waiting for the client to connect

Fix #707