### PR TITLE
Add `neshClassicCache` and related documentation

### DIFF
--- a/.changeset/large-rats-bake.md
+++ b/.changeset/large-rats-bake.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': minor
+---
+
+Add the new `neshClassicCache` function to the `@neshca/cache-handler/functions` module allowing to cache the result of expensive operations in the `getServerSideProps` and a Next.js Pages API routes.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      HANDLER_PATH: ./cache-handler-${{ matrix.handler }}.mjs
       REDIS_URL: redis://localhost:6379
     services:
       redis:
@@ -59,6 +58,12 @@ jobs:
           node-version-file: '.nvmrc'
           check-latest: true
           cache: 'npm'
+      - name: Replace Path with Sed
+        run: |
+          if [ "${{ matrix.handler }}" == "redis-strings" ]; then
+            sed -i 's/cache-handler-redis-stack/cache-handler-redis-strings/g' apps/cache-testing/next.config.mjs
+            sed -i 's/cache-handler-redis-stack/cache-handler-redis-strings/g' apps/cache-testing/src/instrumentation.ts
+          fi
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Dependencies](https://img.shields.io/npm/dm/@neshca/cache-handler)](https://www.npmjs.com/package/@neshca/cache-handler)
 [![License](https://img.shields.io/npm/l/express.svg)](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/LICENSE)
 
-Welcome to [`@neshca/cache-handler`](./packages/cache-handler/README.md) (pronounced /ˈnæʃkʌ/), a specialized ISR/Data cache API crafted for Next.js applications. This library simplifies configuring shared cache strategies in distributed environments, such as multiple, independent application instances. It offers a flexible and easy-to-integrate solution for custom cache strategies, especially for Redis.
+Welcome to [`@neshca/cache-handler`](./packages/cache-handler/README.md) (pronounced `/ˈnæʃkʌ/`), a specialized ISR/Data cache API crafted for Next.js applications. This library simplifies configuring shared cache strategies in distributed environments, such as multiple, independent application instances. It offers a flexible and easy-to-integrate solution for custom cache strategies, especially for Redis.
 
 ### Features
 
@@ -14,6 +14,7 @@ Welcome to [`@neshca/cache-handler`](./packages/cache-handler/README.md) (pronou
 - **TTL Management**: Automatic cache cleanup to keep storage space efficient.
 - **Support for Next.js Routers**: Full support and one setup for the Pages and the App Router.
 - **`neshCache` Function**: Utilize the [`neshCache` ↗](https://caching-tools.github.io/next-shared-cache/functions/nesh-cache) function to replace `unstable_cache` for more control over caching.
+- **`neshClassicCache` Function**: Use the CacheHandler in the Pages Router to cache the result of expensive operations in the `getServerSideProps` and API routes.
 - **Pre-populate the Cache with Initial Data**: Automatically pre-populate the cache with the initial data when the application starts using the [instrumentation hook ↗](https://caching-tools.github.io/next-shared-cache/usage/populating-cache-on-start).
 
 ## Getting Started

--- a/apps/cache-testing/.env.example
+++ b/apps/cache-testing/.env.example
@@ -3,4 +3,3 @@ REMOTE_CACHE_SERVER_BASE_URL=http://localhost:8080
 HOSTNAME=localhost
 PPR_ENABLED=false
 NEXT_PRIVATE_DEBUG_CACHE=1
-HANDLER_PATH=./cache-handler-redis-stack.mjs

--- a/apps/cache-testing/next.config.mjs
+++ b/apps/cache-testing/next.config.mjs
@@ -2,7 +2,7 @@
 
 import path from 'node:path';
 
-const cacheHandler = path.resolve(process.env.HANDLER_PATH ?? './cache-handler-redis-stack.mjs');
+const cacheHandler = path.resolve('./cache-handler-redis-stack.mjs');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/apps/cache-testing/src/pages/api/pages-cached-api.ts
+++ b/apps/cache-testing/src/pages/api/pages-cached-api.ts
@@ -1,0 +1,54 @@
+import { formatTime } from 'cache-testing/utils/format-time';
+import type { CountBackendApiResponseJson } from 'cache-testing/utils/types';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { neshClassicCache } from '@neshca/cache-handler/functions';
+
+export const config = {
+    runtime: 'nodejs',
+};
+
+const fetchWithCache = neshClassicCache(async (url: URL | string) => {
+    const result = await fetch(url);
+
+    if (!result.ok) {
+        throw new Error('Failed to fetch');
+    }
+
+    const json = (await result.json()) as CountBackendApiResponseJson;
+
+    return json;
+});
+
+export default async function handler(request: NextApiRequest, response: NextApiResponse): Promise<void> {
+    if (request.method !== 'GET') {
+        return response.status(405).send(null);
+    }
+
+    const path = request.url;
+
+    const pathAndTag = '/count/pages/api/api/200';
+
+    const revalidate = 5;
+
+    const url = new URL(pathAndTag, 'http://localhost:8081');
+
+    const result = await fetchWithCache({ revalidate, tags: [String(path)], responseContext: response }, url);
+
+    if (!result) {
+        return response.status(404).send(null);
+    }
+
+    const parsedResult = result;
+
+    response.json({
+        props: {
+            count: parsedResult.count,
+            time: formatTime(parsedResult.unixTimeMs),
+            revalidateAfter: formatTime(parsedResult.unixTimeMs + revalidate * 1000),
+            timeMs: parsedResult.unixTimeMs,
+            revalidateAfterMs: parsedResult.unixTimeMs + revalidate * 1000,
+            path,
+        },
+    });
+}

--- a/apps/cache-testing/src/pages/pages/no-paths/ssr-with-cache/200.tsx
+++ b/apps/cache-testing/src/pages/pages/no-paths/ssr-with-cache/200.tsx
@@ -1,0 +1,10 @@
+import { CommonPagesPage } from 'cache-testing/utils/common-pages-page';
+import { createPagesGetServerSideProps } from 'cache-testing/utils/create-pages-get-get-server-side-props-cached';
+
+export const config = {
+    runtime: 'nodejs',
+};
+
+export const getServerSideProps = createPagesGetServerSideProps('pages/no-paths/ssr-with-cache/200');
+
+export default CommonPagesPage;

--- a/apps/cache-testing/src/utils/create-pages-get-get-server-side-props-cached.ts
+++ b/apps/cache-testing/src/utils/create-pages-get-get-server-side-props-cached.ts
@@ -1,0 +1,50 @@
+import type { GetServerSideProps, GetServerSidePropsResult } from 'next';
+
+import { neshClassicCache } from '@neshca/cache-handler/functions';
+import type { CountBackendApiResponseJson, PageProps } from './types';
+
+const fetchWithCache = neshClassicCache(async (url: URL | string) => {
+    const result = await fetch(url);
+
+    if (!result.ok) {
+        throw new Error('Failed to fetch');
+    }
+
+    const json = (await result.json()) as CountBackendApiResponseJson;
+
+    return json;
+});
+
+export function createPagesGetServerSideProps(path: string): GetServerSideProps<PageProps> {
+    return async function getServerSideProps({ res }): Promise<GetServerSidePropsResult<PageProps>> {
+        const pathAndTag = `/count/${path}`;
+
+        const revalidate = 5;
+
+        const url = new URL(pathAndTag, 'http://localhost:8081');
+
+        const result = await fetchWithCache(
+            {
+                revalidate,
+                tags: [`/${path}`],
+                responseContext: res,
+            },
+            url,
+        );
+
+        if (!result) {
+            return { notFound: true };
+        }
+
+        const parsedResult = result;
+
+        return {
+            props: {
+                count: parsedResult.count,
+                time: parsedResult.unixTimeMs,
+                revalidateAfter: revalidate * 1000,
+                path,
+            },
+        };
+    };
+}

--- a/apps/cache-testing/tests/pages.spec.ts
+++ b/apps/cache-testing/tests/pages.spec.ts
@@ -1,5 +1,6 @@
 import Timers from 'node:timers/promises';
 import { expect, test } from '@playwright/test';
+import { revalidateByApi } from './test-helpers';
 
 const paths = [
     '/pages/with-paths/fallback-blocking/200',
@@ -326,5 +327,181 @@ test.describe('SSR', () => {
         const valueFromPageAfterReload = Number.parseInt((await page.getByTestId('data').innerText()).valueOf(), 10);
 
         expect(valueFromPageAfterReload - valueFromPage === 1).toBe(true);
+    });
+});
+
+test.describe('SSR neshClassicCache', () => {
+    const path = '/pages/no-paths/ssr-with-cache/200';
+
+    test('If revalidate is called, then page should be fresh after reload', async ({ page, baseURL }) => {
+        const url = new URL(path, `${baseURL}:3000`);
+
+        await page.goto(url.href);
+
+        const response = await revalidateByApi(path, `${baseURL}:3000`);
+
+        expect(response.revalidated).toBe(true);
+
+        await page.reload();
+
+        await expect(page.getByTestId('cache-state')).toContainText('fresh');
+    });
+
+    test('If revalidate is called on page A, then page B should be fresh on load and value must be updated', async ({
+        context,
+        baseURL,
+    }) => {
+        const appAUrl = new URL(path, `${baseURL}:3000`);
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        const appA = await context.newPage();
+
+        await appA.goto(appAUrl.href);
+
+        await expect(appA.getByTestId('cache-state')).toContainText('fresh');
+
+        const valueFromPageA = Number.parseInt((await appA.getByTestId('data').innerText()).valueOf(), 10);
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        const appBUrl = new URL(path, `${baseURL}:3001`);
+
+        const appB = await context.newPage();
+
+        await appB.goto(appBUrl.href);
+
+        await expect(appA.getByTestId('cache-state')).toContainText('fresh');
+
+        const valueFromPageB = Number.parseInt((await appB.getByTestId('data').innerText()).valueOf(), 10);
+
+        expect(valueFromPageB - valueFromPageA === 1).toBe(true);
+    });
+
+    test('Page should be fresh after becoming stale and reloaded twice', async ({ page, baseURL }) => {
+        const url = new URL(path, `${baseURL}:3000`);
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        await page.goto(url.href);
+
+        await expect(page.getByTestId('cache-state')).toContainText('fresh');
+
+        await expect(page.getByTestId('cache-state')).toContainText('stale', { timeout: 7500 });
+
+        await page.reload();
+
+        await expect(page.getByTestId('cache-state')).toContainText('stale');
+
+        await page.reload();
+
+        await expect(page.getByTestId('cache-state')).toContainText('fresh');
+    });
+});
+
+test.describe('API route neshClassicCache', () => {
+    const path = '/api/pages-cached-api';
+
+    test('If revalidate is called, then page should be fresh after reload', async ({ baseURL }) => {
+        const url = new URL(path, `${baseURL}:3000`);
+
+        const revalidateByApiResponse = await revalidateByApi(path, `${baseURL}:3000`);
+
+        expect(revalidateByApiResponse.revalidated).toBe(true);
+
+        const response = await fetch(url.href);
+
+        if (!response.ok) {
+            throw new Error('Failed to fetch');
+        }
+
+        const json = (await response.json()) as { props: { count: number; timeMs: string; revalidateAfterMs: string } };
+
+        const time = Number.parseInt(json.props.timeMs, 10);
+
+        const revalidateAfter = Number.parseInt(json.props.revalidateAfterMs, 10);
+
+        expect(time < revalidateAfter).toBe(true);
+    });
+
+    test('If revalidate is called on page A, then page B should be fresh on load and value must be updated', async ({
+        baseURL,
+    }) => {
+        const appAUrl = new URL(path, `${baseURL}:3000`);
+
+        const appBUrl = new URL(path, `${baseURL}:3001`);
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        const appAResponse = await fetch(appAUrl.href);
+
+        if (!appAResponse.ok) {
+            throw new Error('Failed to fetch');
+        }
+
+        const appAJson = (await appAResponse.json()) as {
+            props: { count: number; timeMs: string; revalidateAfterMs: string };
+        };
+
+        const time = Number.parseInt(appAJson.props.timeMs, 10);
+
+        const revalidateAfter = Number.parseInt(appAJson.props.revalidateAfterMs, 10);
+
+        expect(time < revalidateAfter).toBe(true);
+
+        const appACount = appAJson.props.count;
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        const appBResponse = await fetch(appBUrl.href);
+
+        if (!appBResponse.ok) {
+            throw new Error('Failed to fetch');
+        }
+
+        const appBJson = (await appBResponse.json()) as {
+            props: { count: number; timeMs: string; revalidateAfterMs: string };
+        };
+
+        const appBCount = appBJson.props.count;
+
+        expect(appBCount - appACount === 1).toBe(true);
+    });
+
+    test('Page should be fresh after becoming stale and reloaded twice', async ({ baseURL }) => {
+        const url = new URL(path, `${baseURL}:3000`);
+
+        await revalidateByApi(path, `${baseURL}:3000`);
+
+        const response1 = await fetch(url.href);
+
+        if (!response1.ok) {
+            throw new Error('Failed to fetch');
+        }
+
+        const json1 = (await response1.json()) as {
+            props: { count: number; timeMs: string; revalidateAfterMs: string };
+        };
+
+        const time = Number.parseInt(json1.props.timeMs, 10);
+
+        const revalidateAfter = Number.parseInt(json1.props.revalidateAfterMs, 10);
+
+        expect(time < revalidateAfter).toBe(true);
+
+        await Timers.setTimeout(revalidateAfter - Date.now());
+
+        await fetch(url.href);
+        const response2 = await fetch(url.href);
+
+        if (!response2.ok) {
+            throw new Error('Failed to fetch');
+        }
+
+        const json2 = (await response2.json()) as {
+            props: { count: number; timeMs: string; revalidateAfterMs: string };
+        };
+
+        expect(json2.props.count - json1.props.count === 1).toBe(true);
     });
 });

--- a/apps/cache-testing/tests/test-helpers.ts
+++ b/apps/cache-testing/tests/test-helpers.ts
@@ -29,3 +29,28 @@ export async function refreshPageCache(page: Page, by: 'tag' | 'path') {
 
     await page.reload();
 }
+
+export async function revalidateByApi(
+    path: string,
+    base: string,
+    router: 'app' | 'pages' = 'app',
+    by: 'path' | 'tag' = 'tag',
+): Promise<{ revalidated: boolean; now: string }> {
+    const url = new URL(`/api/revalidate-${router}`, base);
+
+    url.searchParams.append(by, path);
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+        throw new Error('Failed to revalidate');
+    }
+
+    const json = (await response.json()) as { revalidated: boolean; now: string };
+
+    if (!json.revalidated) {
+        throw new Error('Failed to revalidate');
+    }
+
+    return json;
+}

--- a/docs/cache-handler-docs/src/pages/functions/_meta.ts
+++ b/docs/cache-handler-docs/src/pages/functions/_meta.ts
@@ -1,3 +1,4 @@
 export default {
     'nesh-cache': 'neshCache',
+    'nesh-classic-cache': 'neshClassicCache',
 };

--- a/docs/cache-handler-docs/src/pages/functions/nesh-cache.mdx
+++ b/docs/cache-handler-docs/src/pages/functions/nesh-cache.mdx
@@ -30,7 +30,7 @@ This is an object that controls how the cache behaves. It can contain the follow
 
 ## Example
 
-```jsx filename="./src/app/page.js" copy
+```jsx filename="src/app/page.js" copy
 import { neshCache } from '@neshca/cache-handler/functions';
 import axios from 'axios';
 

--- a/docs/cache-handler-docs/src/pages/functions/nesh-classic-cache.mdx
+++ b/docs/cache-handler-docs/src/pages/functions/nesh-classic-cache.mdx
@@ -1,0 +1,80 @@
+import { Callout } from 'nextra/components';
+
+# neshClassicCache
+
+`neshClassicCache` allows you to cache the results of expensive operations, like database queries, and reuse them across multiple requests. Unlike the [`neshCache`](/functions/nesh-cache) or [`unstable_cache` ↗](https://nextjs.org/docs/app/api-reference/functions/unstable_cache) function, `neshClassicCache` must be used in a Next.js Pages Router allowing users to cache data in the `getServerSideProps` and API routes.
+
+This function is experimental, the API may change in the future. Use with caution.
+
+<Callout type="info">
+  Cache entries created with `neshClassicCache` can be revalidated only by the [`revalidateTag`
+  ↗](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) method.
+</Callout>
+
+## Parameters
+
+### `fetchData`
+
+This is an asynchronous function that fetches the data you want to cache. It must be a function that returns a `Promise`.
+
+### `commonOptions`
+
+This is an object that controls how the cache behaves. It can contain the following properties:
+
+- `tags` - An array of tags to associate with the cached result. Tags are used to revalidate the cache using the `revalidateTag` and `revalidatePath` functions.
+
+- `revalidate` - The revalidation interval in seconds. Must be a positive integer or `false` to disable revalidation. Defaults to `export const revalidate = time;` in the current route.
+
+- `argumentsSerializer` - A function that serializes the arguments passed to the callback function. Use it to create a cache key. Defaults to `JSON.stringify(args)`.
+
+- `resultSerializer` - A function that serializes the result of the callback function.Defaults to `Buffer.from(JSON.stringify(data)).toString('base64')`.
+
+- `resultDeserializer` - A function that deserializes the string representation of the result of the callback function. Defaults to `JSON.parse(Buffer.from(data, 'base64').toString('utf-8'))`.
+
+- `responseContext` - The response context object. If provided, it is used to set the cache headers acoording to the `revalidate` option. Defaults to `undefined`.
+
+## Returns
+
+`neshClassicCache` returns a function that when invoked, returns a `Promise` that resolves to the cached data. If the data is not in the cache, the provided function will be invoked, and its result will be cached and returned. The first argument is the `options` which can be used to override the common [`options`](/functions/nesh-classic-cache#commonoptions). In addition, there is a `cacheKey` option that can be used to provide a custom cache key.
+
+## Example
+
+```jsx filename="src/pages/api/api-example.js" copy
+import { neshClassicCache } from '@neshca/cache-handler/functions';
+import axios from 'axios';
+
+export const config = {
+  runtime: 'nodejs',
+};
+
+async function getViaAxios(url) {
+  try {
+    return (await axios.get(url.href)).data;
+  } catch (_error) {
+    return null;
+  }
+}
+
+const cachedAxios = neshClassicCache(getViaAxios);
+
+export default async function handler(request, response) {
+  if (request.method !== 'GET') {
+    return response.status(405).send(null);
+  }
+
+  const revalidate = 5;
+
+  const url = new URL('https://api.example.com/data.json');
+
+  // Add tags to be able to revalidate the cache
+  const data = await cachedAxios({ revalidate, tags: [url.pathname], responseContext: response }, url);
+
+  if (!data) {
+    response.status(404).send('Not found');
+
+    return;
+  }
+
+  response.json(data);
+}
+```

--- a/docs/cache-handler-docs/src/pages/index.mdx
+++ b/docs/cache-handler-docs/src/pages/index.mdx
@@ -12,6 +12,8 @@ Next.js applications are often deployed in a self-hosted distributed environment
 - **TTL Management**: Automatic cache cleanup to keep storage space efficient.
 - **Support for Next.js Routers**: Full support and one setup for the Pages and the App Router.
 - **`neshCache` Function**: Utilize the [`neshCache`](/functions/nesh-cache) function to replace `unstable_cache` for more control over caching.
+- **`neshClassicCache` Function**: Use the CacheHandler in the Pages Router to cache the result of expensive operations in the `getServerSideProps` and API routes.
+- **Pre-populate the Cache with Initial Data**: Automatically pre-populate the cache with the initial data when the application starts using the [instrumentation hook ↗](/usage/populating-cache-on-start).
 
 ## Getting Started
 

--- a/docs/cache-handler-docs/theme.config.jsx
+++ b/docs/cache-handler-docs/theme.config.jsx
@@ -43,19 +43,19 @@ export default {
         ),
     },
     banner: {
-        key: 'version-1.7.0',
+        key: 'version-1.8.0',
         content: (
             <div>
-                🎉 Version 1.7.0 is out! It has{' '}
+                🎉 Version 1.8.0 is out! Use shared cache for the Next.js Pages API routes and getServerSideProps with{' '}
                 <a
-                    href="/usage/populating-cache-on-start"
+                    href="/functions/nesh-classic-cache"
                     style={{
                         color: 'lightgreen',
+                        fontFamily: 'monospace',
                     }}
                 >
-                    a new instrumentation hook
-                </a>{' '}
-                to pre-populate the cache with pre-rendered pages on startup.
+                    neshClassicCache
+                </a>
             </div>
         ),
     },

--- a/internal/next-common/src/next-common.ts
+++ b/internal/next-common/src/next-common.ts
@@ -1,13 +1,10 @@
 // biome-ignore lint/style/useNodejsImportProtocol: RollupError: "OutgoingHttpHeaders" is not exported by "node:http"
 import type { OutgoingHttpHeaders } from 'http';
-
-import type { RouteMetadata as NextRouteMetadata } from 'next/dist/export/routes/types';
 import type { CacheHandler, CacheHandlerValue as NextCacheHandlerValue } from 'next/dist/server/lib/incremental-cache';
 import type FileSystemCache from 'next/dist/server/lib/incremental-cache/file-system-cache';
-import type { Revalidate } from 'next/dist/server/lib/revalidate';
+import type { IncrementalCacheValue } from 'next/dist/server/response-cache/types';
 
 export type { PrerenderManifest } from 'next/dist/build';
-export type { Revalidate } from 'next/dist/server/lib/revalidate';
 export type { CacheHandler, CacheHandlerContext } from 'next/dist/server/lib/incremental-cache';
 export type {
     CachedRedirectValue,
@@ -16,8 +13,15 @@ export type {
     CachedFetchValue,
     IncrementalCacheValue,
     IncrementalCacheEntry,
-    IncrementalCacheKindHint,
 } from 'next/dist/server/response-cache/types';
+
+export type NextRouteMetadata = {
+    status: number | undefined;
+    headers: OutgoingHttpHeaders | undefined;
+    postponed: string | undefined;
+};
+
+export type Revalidate = false | number;
 
 /**
  * A set of time periods and timestamps for controlling cache behavior.
@@ -97,14 +101,9 @@ export type UnwrappedCacheHandler = {
     revalidateTag(...args: CacheHandlerParametersRevalidateTag): Awaited<CacheHandlerReturnTypeRevalidateTag>;
 };
 
-export type IncrementalCachedPageValue = {
-    kind: 'PAGE';
-    html: string;
-    pageData: object;
-    postponed: string | undefined;
-    headers: OutgoingHttpHeaders | undefined;
-    status: number | undefined;
-};
+type ExtractIncrementalCacheKind<T, Kind> = T extends { kind: Kind } ? T : never;
+
+export type IncrementalCachedPageValue = ExtractIncrementalCacheKind<IncrementalCacheValue, 'PAGE'>;
 
 export type TagsManifest = {
     version: 1;

--- a/packages/cache-handler/README.md
+++ b/packages/cache-handler/README.md
@@ -8,9 +8,9 @@
 
 ## Latest Release
 
-🎉 **Version 1.7.0** has been released! It now includes the [`registerInitialCache` instrumentation hook ↗](https://caching-tools.github.io/next-shared-cache/usage/populating-cache-on-start), which allows the cache to be pre-populated with the initial data when the application starts.
+🎉 **Version 1.8.0** has been released! It now includes the [`neshClassicCache` function ↗](https://caching-tools.github.io/next-shared-cache/functions/nesh-classic-cache), that allows you to cache the results of expensive operations in the `getServerSideProps` and API routes.
 
-Do not forget the [`experimental-redis-cluster`](https://caching-tools.github.io/next-shared-cache/handlers/experimental-redis-cluster) Handler for Redis Cluster support from a previous release.
+Do not forget the [`registerInitialCache` instrumentation hook ↗](https://caching-tools.github.io/next-shared-cache/usage/populating-cache-on-start), that allows the cache to be pre-populated with the initial data when the application starts.
 
 Check out the [changelog](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/CHANGELOG.md) for more details.
 
@@ -37,6 +37,7 @@ Welcome to `@neshca/cache-handler` (pronounced /ˈnæʃkʌ/), a specialized ISR/
 - **TTL Management**: Automatic cache cleanup to keep storage space efficient.
 - **Support for Next.js Routers**: Full support and one setup for the Pages and the App Router.
 - **`neshCache` Function**: Utilize the [`neshCache` ↗](https://caching-tools.github.io/next-shared-cache/functions/nesh-cache) function to replace `unstable_cache` for more control over caching.
+- **`neshClassicCache` Function**: Use the CacheHandler in the Pages Router to cache the result of expensive operations in the `getServerSideProps` and API routes.
 - **Pre-populate the Cache with Initial Data**: Automatically pre-populate the cache with the initial data when the application starts using the [instrumentation hook ↗](https://caching-tools.github.io/next-shared-cache/usage/populating-cache-on-start).
 
 ## Getting Started

--- a/packages/cache-handler/src/functions/functions.ts
+++ b/packages/cache-handler/src/functions/functions.ts
@@ -1,1 +1,2 @@
 export { neshCache } from './nesh-cache';
+export { neshClassicCache } from './nesh-classic-cache';

--- a/packages/cache-handler/src/functions/nesh-classic-cache.ts
+++ b/packages/cache-handler/src/functions/nesh-classic-cache.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import type { Revalidate } from '@neshca/next-common';
+import { staticGenerationAsyncStorage } from 'next/dist/client/components/static-generation-async-storage.external.js';
+import type { IncrementalCache } from 'next/dist/server/lib/incremental-cache';
+import type { CacheHandler } from '../cache-handler';
+import { TIME_ONE_YEAR } from '../constants';
+
+declare global {
+    var __incrementalCache: IncrementalCache | undefined;
+}
+
+function hashCacheKey(url: string): string {
+    // this should be bumped anytime a fix is made to cache entries
+    // that should bust the cache
+    const MAIN_KEY_PREFIX = 'nesh-pages-cache-v1';
+
+    const cacheString = JSON.stringify([MAIN_KEY_PREFIX, url]);
+
+    return createHash('sha256').update(cacheString).digest('hex');
+}
+
+/**
+ * Serializes the given arguments into a string representation.
+ *
+ * @param object - The arguments to be serialized.
+ *
+ * @returns The serialized string representation of the arguments.
+ */
+function serializeArguments(object: object): string {
+    return JSON.stringify(object);
+}
+
+/**
+ * Serializes the given object into a string representation.
+ *
+ * @param object - The object to be serialized.
+ *
+ * @returns The serialized string representation of the object.
+ */
+function serializeResult(object: object): string {
+    return Buffer.from(JSON.stringify(object), 'utf-8').toString('base64');
+}
+
+/**
+ * Deserializes a string representation of an object into its original form.
+ *
+ * @param string - The string representation of the object.
+ *
+ * @returns The deserialized object.
+ */
+function deserializeResult<T>(string: string): T {
+    return JSON.parse(Buffer.from(string, 'base64').toString('utf-8'));
+}
+
+/**
+ * @template Arguments - The type of the arguments passed to the callback function.
+ *
+ * @template Result - The type of the value returned by the callback function.
+ */
+type Callback<Arguments extends unknown[], Result> = (...args: Arguments) => Result;
+
+/**
+ * An object containing options for the cache.
+ */
+type NeshClassicCacheOptions<Arguments extends unknown[], Result> = {
+    /**
+     * The response context object.
+     * It is used to set the cache headers.
+     */
+    responseContext?: object & {
+        setHeader(name: string, value: number | string | readonly string[]): unknown;
+    };
+    /**
+     * An array of tags to associate with the cached result.
+     * Tags are used to revalidate the cache using the `revalidateTag` function.
+     */
+    tags?: string[];
+    /**
+     * The revalidation interval in seconds.
+     * Must be a positive integer or `false` to disable revalidation.
+     *
+     * @default revalidate // of the current route
+     */
+    revalidate?: Revalidate;
+    /**
+     * A custom cache key to be used instead of creating one from the arguments.
+     */
+    cacheKey?: string;
+    /**
+     * A function that serializes the arguments passed to the callback function.
+     * Use it to create a cache key.
+     *
+     * @default (args) => JSON.stringify(args)
+     *
+     * @param callbackArguments - The arguments passed to the callback function.
+     */
+    argumentsSerializer?(callbackArguments: Arguments): string;
+    /**
+     *
+     * A function that serializes the result of the callback function.
+     *
+     * @default (result) => Buffer.from(JSON.stringify(result)).toString('base64')
+     *
+     * @param result - The result of the callback function.
+     */
+    resultSerializer?(result: Result): string;
+    /**
+     * A function that deserializes the string representation of the result of the callback function.
+     *
+     * @default (string) => JSON.parse(Buffer.from(string, 'base64').toString('utf-8'))
+     *
+     * @param string - The string representation of the result of the callback function.
+     */
+    resultDeserializer?(string: string): Result;
+};
+
+/**
+ * An object containing common options for the cache.
+ */
+type CommonNeshClassicCacheOptions<Arguments extends unknown[], Result> = Omit<
+    NeshClassicCacheOptions<Arguments, Result>,
+    'cacheKey' | 'responseContext'
+>;
+
+/**
+ * Experimental implementation of the "`unstable_cache`" for classic Next.js Pages Router.
+ * It allows to cache data in the `getServerSideProps` and API routes.
+ *
+ * The API may change in the future. Use with caution.
+ *
+ * Caches the result of a callback function and returns a cached version if available.
+ * If not available, it executes the callback function, caches the result, and returns it.
+ *
+ * @param callback - The callback function to be cached.
+ *
+ * @param options - An object containing options for the cache.
+ *
+ * @param options.responseContext - The response context object.
+ * It is used to set the cache headers.
+ *
+ * @param options.tags - An array of tags to associate with the cached result.
+ * Tags are used to revalidate the cache using the `revalidateTag` function.
+ *
+ * @param options.revalidate - The revalidation interval in seconds.
+ * Must be a positive integer or `false` to disable revalidation.
+ * Defaults to `export const revalidate = time;` in the current route.
+ *
+ * @param options.argumentsSerializer - A function that serializes the arguments passed to the callback function.
+ * Use it to create a cache key. Defaults to `JSON.stringify(args)`.
+ *
+ * @param options.resultSerializer - A function that serializes the result of the callback function.
+ * Defaults to `Buffer.from(JSON.stringify(data)).toString('base64')`.
+ *
+ * @param options.resultDeserializer - A function that deserializes the string representation of the result of the callback function.
+ * Defaults to `JSON.parse(Buffer.from(data, 'base64').toString('utf-8'))`.
+ *
+ * @returns The callback wrapped in a caching function.
+ * First argument is the cache options which can be used to override the common options.
+ * In addition, there is a `cacheKey` option that can be used to provide a custom cache key.
+ *
+ * @throws If the `neshClassicCache` function is not used in a Next.js Pages directory or if the `revalidate` option is invalid.
+ *
+ * @example file: `src/pages/api/api-example.js`
+ *
+ * ```js
+ * import { neshClassicCache } from '@neshca/cache-handler/functions';
+ * import axios from 'axios';
+ *
+ * export const config = {
+ *   runtime: 'nodejs',
+ * };
+ *
+ * async function getViaAxios(url) {
+ *   try {
+ *     return (await axios.get(url.href)).data;
+ *   } catch (_error) {
+ *     return null;
+ *   }
+ * }
+ *
+ * const cachedAxios = neshClassicCache(getViaAxios);
+ *
+ * export default async function handler(request, response) {
+ *   if (request.method !== 'GET') {
+ *     return response.status(405).send(null);
+ *   }
+ *
+ *   const revalidate = 5;
+ *
+ *   const url = new URL('https://api.example.com/data.json');
+ *
+ *   // Add tags to be able to revalidate the cache
+ *   const data = await cachedAxios({ revalidate, tags: [url.pathname], responseContext: response }, url);
+ *
+ *   if (!data) {
+ *     response.status(404).send('Not found');
+ *
+ *     return;
+ *   }
+ *
+ *   response.json(data);
+ * }
+ * ```
+ *
+ * @remarks
+ * - This function is intended to be used in a Next.js Pages directory.
+ *
+ * @since 1.8.0
+ */
+export function neshClassicCache<Arguments extends unknown[], Result extends Promise<unknown>>(
+    callback: Callback<Arguments, Result>,
+    commonOptions?: CommonNeshClassicCacheOptions<Arguments, Result>,
+) {
+    if (commonOptions?.resultSerializer && !commonOptions?.resultDeserializer) {
+        throw new Error('neshClassicCache: if you provide a resultSerializer, you must provide a resultDeserializer.');
+    }
+
+    if (commonOptions?.resultDeserializer && !commonOptions?.resultSerializer) {
+        throw new Error('neshClassicCache: if you provide a resultDeserializer, you must provide a resultSerializer.');
+    }
+
+    const commonRevalidate = commonOptions?.revalidate ?? false;
+    const commonArgumentsSerializer = commonOptions?.argumentsSerializer ?? serializeArguments;
+    const commonResultSerializer = commonOptions?.resultSerializer ?? serializeResult;
+    const commonResultDeserializer = commonOptions?.resultDeserializer ?? deserializeResult;
+
+    async function cachedCallback(
+        options: NeshClassicCacheOptions<Arguments, Result>,
+        ...args: Arguments
+    ): Promise<Result | null> {
+        const store = staticGenerationAsyncStorage.getStore();
+
+        assert(!store?.incrementalCache, 'neshClassicCache must be used in a Next.js Pages directory.');
+
+        const cacheHandler = globalThis?.__incrementalCache?.cacheHandler as
+            | InstanceType<typeof CacheHandler>
+            | undefined;
+
+        assert(cacheHandler, 'neshClassicCache must be used in a Next.js Pages directory.');
+
+        const {
+            responseContext,
+            tags = [],
+            revalidate = commonRevalidate,
+            cacheKey,
+            argumentsSerializer = commonArgumentsSerializer,
+            resultDeserializer = commonResultDeserializer,
+            resultSerializer = commonResultSerializer,
+        } = options ?? {};
+
+        assert(
+            revalidate === false || (revalidate > 0 && Number.isInteger(revalidate)),
+            'neshClassicCache: revalidate must be a positive integer or false.',
+        );
+
+        responseContext?.setHeader('Cache-Control', `public, s-maxage=${revalidate}, stale-while-revalidate`);
+
+        const uniqueTags = new Set<string>();
+
+        for (const tag of tags) {
+            if (typeof tag === 'string') {
+                uniqueTags.add(tag);
+            } else {
+                console.warn(`neshClassicCache: Invalid tag: ${tag}. Skipping it. Expected a string.`);
+            }
+        }
+
+        const allTags = Array.from(uniqueTags);
+
+        const key = hashCacheKey(`nesh-classic-cache-${cacheKey ?? argumentsSerializer(args)}`);
+
+        const cacheData = await cacheHandler.get(key, {
+            revalidate,
+            tags: allTags,
+            kindHint: 'fetch',
+            fetchUrl: 'neshClassicCache',
+        });
+
+        if (
+            cacheData?.value?.kind === 'FETCH' &&
+            cacheData.lifespan &&
+            cacheData.lifespan.staleAt > Date.now() / 1000
+        ) {
+            return resultDeserializer(cacheData.value.data.body);
+        }
+
+        const data: Result = await callback(...args);
+
+        cacheHandler.set(
+            key,
+            {
+                kind: 'FETCH',
+                data: {
+                    body: resultSerializer(data),
+                    headers: {},
+                    url: 'neshClassicCache',
+                },
+                revalidate: revalidate || TIME_ONE_YEAR,
+            },
+            { revalidate, tags, fetchCache: true, fetchUrl: 'neshClassicCache' },
+        );
+
+        if (
+            cacheData?.value?.kind === 'FETCH' &&
+            cacheData?.lifespan &&
+            cacheData.lifespan.expireAt > Date.now() / 1000
+        ) {
+            return resultDeserializer(cacheData.value.data.body);
+        }
+
+        return data;
+    }
+
+    return cachedCallback;
+}

--- a/packages/cache-handler/src/instrumentation/instrumentation.ts
+++ b/packages/cache-handler/src/instrumentation/instrumentation.ts
@@ -1,1 +1,1 @@
-export { registerInitialCache, type RegisterInitialCacheOptions } from './instrumentation.cache';
+export { registerInitialCache, type RegisterInitialCacheOptions } from './register-initial-cache';

--- a/packages/cache-handler/src/instrumentation/register-initial-cache.ts
+++ b/packages/cache-handler/src/instrumentation/register-initial-cache.ts
@@ -1,11 +1,9 @@
 import { promises as fsPromises } from 'node:fs';
 import path from 'node:path';
-import type { CachedFetchValue } from '@neshca/next-common';
+import type { CachedFetchValue, Revalidate, RouteMetadata } from '@neshca/next-common';
 import { PRERENDER_MANIFEST, SERVER_DIRECTORY } from 'next/constants';
 import type { PrerenderManifest } from 'next/dist/build';
-import type { RouteMetadata } from 'next/dist/export/routes/types';
 import { CACHE_ONE_YEAR } from 'next/dist/lib/constants';
-import type { Revalidate } from 'next/dist/server/lib/revalidate';
 import { getTagsFromHeaders } from '../helpers/get-tags-from-headers';
 
 type CacheHandlerType = typeof import('../cache-handler').CacheHandler;
@@ -107,7 +105,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
         if (debug) {
             console.warn(
                 '[CacheHandler] [%s] %s %s',
-                'instrumentation.cache',
+                'registerInitialCache',
                 'Failed to read prerender manifest',
                 `Error: ${error}`,
             );
@@ -129,7 +127,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
         if (debug) {
             console.warn(
                 '[CacheHandler] [%s] %s %s',
-                'instrumentation.cache',
+                'registerInitialCache',
                 'Failed to create CacheHandler instance',
                 `Error: ${error}`,
             );
@@ -150,7 +148,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to read route body file',
                     `Error: ${error}`,
                 );
@@ -177,7 +175,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to read route body or metadata file, or parse metadata',
                     `Error: ${error}`,
                 );
@@ -201,7 +199,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to set route cache. Please check if the CacheHandler is configured correctly',
                     `Error: ${error}`,
                 );
@@ -225,7 +223,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to read page html file',
                     `Error: ${error}`,
                 );
@@ -253,7 +251,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to read page html, page data, or metadata file, or parse metadata',
                     `Error: ${error}`,
                 );
@@ -279,7 +277,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to set page cache. Please check if the CacheHandler is configured correctly',
                     `Error: ${error}`,
                 );
@@ -311,7 +309,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
         if (debug) {
             console.warn(
                 '[CacheHandler] [%s] %s %s',
-                'instrumentation.cache',
+                'registerInitialCache',
                 'Failed to read cache/fetch-cache directory',
                 `Error: ${error}`,
             );
@@ -332,7 +330,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to read fetch cache file',
                     `Error: ${error}`,
                 );
@@ -349,7 +347,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to parse fetch cache file',
                     `Error: ${error}`,
                 );
@@ -371,7 +369,7 @@ export async function registerInitialCache(CacheHandler: CacheHandlerType, optio
             if (debug) {
                 console.warn(
                     '[CacheHandler] [%s] %s %s',
-                    'instrumentation.cache',
+                    'registerInitialCache',
                     'Failed to set fetch cache. Please check if the CacheHandler is configured correctly',
                     `Error: ${error}`,
                 );

--- a/turbo.json
+++ b/turbo.json
@@ -6,14 +6,7 @@
     "tasks": {
         "build": {
             "dependsOn": ["^build"],
-            "env": [
-                "REDIS_URL",
-                "REMOTE_CACHE_SERVER_BASE_URL",
-                "SERVER_STARTED",
-                "PORT",
-                "PPR_ENABLED",
-                "HANDLER_PATH"
-            ],
+            "env": ["REDIS_URL", "REMOTE_CACHE_SERVER_BASE_URL", "SERVER_STARTED", "PORT", "PPR_ENABLED"],
             "outputs": [".next/**", "!.next/cache/**", "dist/**", "out/**"]
         },
         "build:docs": {


### PR DESCRIPTION
Add the new `neshClassicCache` function to the `@neshca/cache-handler/functions` module allowing to cache the result of expensive operations in the `getServerSideProps` and a Next.js Pages API routes.