### PR TITLE
docs: change docs to explicitly say that next 13 and 14 are supported

### DIFF
--- a/docs/cache-handler-docs/src/pages/installation.mdx
+++ b/docs/cache-handler-docs/src/pages/installation.mdx
@@ -7,7 +7,7 @@ This section guides you through the initial setup and basic usage of `@neshca/ca
 ### Prerequisites
 
 - **Node.js:** Version 18.17 or newer.
-- **Next.js:** Version 13.5.1 or newer.
+- **Next.js:** Version 13.5.1 or 14.*.*.
 - **Redis (optional):** Version 4.6.0 or newer.
 
 ### Quick Start Installation


### PR DESCRIPTION
**Problem**
- Currently documentation says that the library works with Next 13 and newer. It's misleading because Next 15 isn't supported yet

**Solution**
- Changed the docs to say that Next 13 and 14 are supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for `@neshca/cache-handler` to support Next.js versions 13.5.1 or 14.*.*.
	- Clarified manual installation steps and provided clear command for installation.
	- Refined integration instructions, emphasizing production use and configuration options for Next.js.
	- Retained sections on cache population and environment variable importance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->