### PR TITLE
Update README and documentation and the default expire age calculation

### DIFF
--- a/.changeset/flat-boxes-build.md
+++ b/.changeset/flat-boxes-build.md
@@ -1,0 +1,5 @@
+---
+'@neshca/cache-handler': minor
+---
+
+Updated the documentation and peer dependencies to explicitly state that only Next.js versions `13.5.x` and `14.x.x` are supported. Modified the default `estimateExpireAge` function to perform the calculation as `(staleAge) => staleAge * 1.5`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Explore the versatility of `@neshca/cache-handler` in our [Examples Section](htt
 
 ## Requirements
 
-- **Next.js**: 13.5.x or 14.x.x.
+- **Next.js**: 13.5.1 or newer (below 15.0.0).
 - **Node.js**: 18.17.0 or newer.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Explore the versatility of `@neshca/cache-handler` in our [Examples Section](htt
 
 ## Requirements
 
-- **Next.js**: 13.5.1 or newer.
+- **Next.js**: 13.5.x or 14.x.x.
 - **Node.js**: 18.17.0 or newer.
 
 ## Documentation

--- a/docs/cache-handler-docs/src/pages/api-reference/ttl-parameters.mdx
+++ b/docs/cache-handler-docs/src/pages/api-reference/ttl-parameters.mdx
@@ -17,7 +17,7 @@ Stale age is the time after which the cache entry is considered stale, can be se
 
 ### `estimateExpireAge`
 
-Estimates the expiration age based on the stale age.
+Estimates the expiration age based on the stale age. Defaults to `(staleAge) => staleAge * 1.5`.
 
 Expire age is the time after which the cache entry is considered expired and should be removed from the cache and must not be served.
 

--- a/docs/cache-handler-docs/src/pages/installation.mdx
+++ b/docs/cache-handler-docs/src/pages/installation.mdx
@@ -7,7 +7,7 @@ This section guides you through the initial setup and basic usage of `@neshca/ca
 ### Prerequisites
 
 - **Node.js:** Version 18.17 or newer.
-- **Next.js:** Version 13.5.1 or newer.
+- **Next.js:** Version 13.5.x or 14.x.x.
 - **Redis (optional):** Version 4.6.0 or newer.
 
 ### Quick Start Installation
@@ -100,7 +100,7 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
    ```js filename="next.config.js" copy
    const nextConfig = {
      cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
-     // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
+     // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.x to 14.0.4
      /* experimental: {
            incrementalCacheHandlerPath:
                process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,

--- a/docs/cache-handler-docs/src/pages/installation.mdx
+++ b/docs/cache-handler-docs/src/pages/installation.mdx
@@ -6,9 +6,9 @@ This section guides you through the initial setup and basic usage of `@neshca/ca
 
 ### Prerequisites
 
-- **Node.js:** Version 18.17 or newer.
-- **Next.js:** Version 13.5.x or 14.x.x.
-- **Redis (optional):** Version 4.6.0 or newer.
+- **Node.js:** 18.17 or newer.
+- **Next.js:** 13.5.1 or newer (below 15.0.0).
+- **Redis (optional):** 4.6.0 or newer.
 
 ### Quick Start Installation
 
@@ -100,7 +100,7 @@ pnpm create next-app --example cache-handler-redis cache-handler-redis-app
    ```js filename="next.config.js" copy
    const nextConfig = {
      cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
-     // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.x to 14.0.4
+     // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
      /* experimental: {
            incrementalCacheHandlerPath:
                process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,

--- a/docs/cache-handler-docs/src/pages/usage/development-environment.mdx
+++ b/docs/cache-handler-docs/src/pages/usage/development-environment.mdx
@@ -7,7 +7,7 @@ The easiest way to turn off the cache handler in a development environment is to
 ```js filename="next.config.js" copy
 const nextConfig = {
   cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
-  // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.x to 14.0.4
+  // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
   /* experimental: {
             incrementalCacheHandlerPath:
                 process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,

--- a/docs/cache-handler-docs/src/pages/usage/development-environment.mdx
+++ b/docs/cache-handler-docs/src/pages/usage/development-environment.mdx
@@ -7,7 +7,7 @@ The easiest way to turn off the cache handler in a development environment is to
 ```js filename="next.config.js" copy
 const nextConfig = {
   cacheHandler: process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,
-  // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.1 to 14.0.4
+  // Use `experimental` option instead of the `cacheHandler` property when using Next.js versions from 13.5.x to 14.0.4
   /* experimental: {
             incrementalCacheHandlerPath:
                 process.env.NODE_ENV === 'production' ? require.resolve('./cache-handler.mjs') : undefined,

--- a/docs/cache-handler-docs/theme.config.jsx
+++ b/docs/cache-handler-docs/theme.config.jsx
@@ -43,19 +43,11 @@ export default {
         ),
     },
     banner: {
-        key: 'version-1.8.0',
+        key: 'version-1.9.0',
         content: (
             <div>
-                🎉 Version 1.8.0 is out! Use shared cache for the Next.js Pages API routes and getServerSideProps with{' '}
-                <a
-                    href="/functions/nesh-classic-cache"
-                    style={{
-                        color: 'lightgreen',
-                        fontFamily: 'monospace',
-                    }}
-                >
-                    neshClassicCache
-                </a>
+                🎉 Version 1.9.0 is out! This is the final release supporting Next.js 13.5.1-14.x. The upcoming version
+                2.0.0 will require Next.js 15.
             </div>
         ),
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17145,7 +17145,7 @@
                 "typescript": "5.7.2"
             },
             "peerDependencies": {
-                "next": ">= 13.5.1",
+                "next": ">= 13.5.1 < 15",
                 "redis": ">= 4.6"
             }
         },

--- a/packages/cache-handler/README.md
+++ b/packages/cache-handler/README.md
@@ -50,7 +50,7 @@ Explore the versatility of `@neshca/cache-handler` in our [Examples Section](htt
 
 ## Requirements
 
-- **Next.js**: 13.5.1 or newer.
+- **Next.js**: 13.5.x or 14.x.x.
 - **Node.js**: 18.17.0 or newer.
 
 ## Documentation

--- a/packages/cache-handler/README.md
+++ b/packages/cache-handler/README.md
@@ -8,9 +8,9 @@
 
 ## Latest Release
 
-🎉 **Version 1.8.0** has been released! It now includes the [`neshClassicCache` function ↗](https://caching-tools.github.io/next-shared-cache/functions/nesh-classic-cache), that allows you to cache the results of expensive operations in the `getServerSideProps` and API routes.
+🎉 **Version 1.9.0** has been released! It changes the default `estimateExpireAge` function to perform the calculation as `(staleAge) => staleAge * 1.5` to better align with the default Next.js cache behavior.
 
-Do not forget the [`registerInitialCache` instrumentation hook ↗](https://caching-tools.github.io/next-shared-cache/usage/populating-cache-on-start), that allows the cache to be pre-populated with the initial data when the application starts.
+This is the final release leading up to version 2.0.0. The upcoming version 2 will bring significant changes and will no longer support Next.js versions 13 and 14. While version 1 will still receive ongoing maintenance, it won't get any new features.
 
 Check out the [changelog](https://github.com/caching-tools/next-shared-cache/blob/canary/packages/cache-handler/CHANGELOG.md) for more details.
 
@@ -50,7 +50,7 @@ Explore the versatility of `@neshca/cache-handler` in our [Examples Section](htt
 
 ## Requirements
 
-- **Next.js**: 13.5.x or 14.x.x.
+- **Next.js**: 13.5.1 or newer (below 15.0.0).
 - **Node.js**: 18.17.0 or newer.
 
 ## Documentation

--- a/packages/cache-handler/package.json
+++ b/packages/cache-handler/package.json
@@ -92,7 +92,7 @@
         "typescript": "5.7.2"
     },
     "peerDependencies": {
-        "next": ">= 13.5.1",
+        "next": ">= 13.5.1 < 15",
         "redis": ">= 4.6"
     },
     "distTags": [

--- a/packages/cache-handler/src/cache-handler.ts
+++ b/packages/cache-handler/src/cache-handler.ts
@@ -168,7 +168,7 @@ export type TTLParameters = {
      * After the stale age, the cache entry is considered stale, can be served from the cache, and should be revalidated.
      * Revalidation is handled by the `CacheHandler` class.
      *
-     * @default (staleAge) => staleAge
+     * @default (staleAge) => staleAge * 1.5
      *
      * @returns The expiration age in seconds.
      *

--- a/packages/cache-handler/src/helpers/create-validated-age-estimation-function.ts
+++ b/packages/cache-handler/src/helpers/create-validated-age-estimation-function.ts
@@ -11,7 +11,7 @@ type EstimateExpireAgeFunction = typeof getInitialExpireAge;
  * @returns The initial expire age.
  */
 export function getInitialExpireAge(staleAge: number): number {
-    return staleAge;
+    return staleAge * 1.5;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated the default behavior of the `estimateExpireAge` function to calculate expiration as `(staleAge) => staleAge * 1.5`.
	- Added documentation on how to populate the cache with prerendered pages.

- **Documentation**
	- Clarified compatibility requirements for Next.js (versions `>= 13.5.1 < 15`).
	- Enhanced installation instructions and emphasized import guidelines for the cache handler.
	- Announced the release of version **1.9.0** and outlined future changes for version **2.0.0**. 

- **Bug Fixes**
	- Corrected the default implementation of the `estimateExpireAge` method in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->