### PR TITLE
Removes next 15 caveat in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Explore the versatility of `@neshca/cache-handler` in our [Examples Section](htt
 
 ## Requirements
 
-- **Next.js**: 13.5.1 or newer (below 15.0.0).
+- **Next.js**: 13.5.1 or newer.
 - **Node.js**: 18.17.0 or newer.
 
 ## Documentation


### PR DESCRIPTION
per package.json, next.js 15 is good to go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Next.js version requirement in the package documentation to support version 13.5.1 or newer, removing the previous upper limit restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->