### PR TITLE
Update On-demand revalidation docs

### DIFF
--- a/.changeset/twelve-items-allow.md
+++ b/.changeset/twelve-items-allow.md
@@ -1,0 +1,5 @@
+---
+"@repo/cache-handler-docs": patch
+---
+
+Update On-demand revalidation docs

--- a/docs/cache-handler-docs/src/app/usage/on-demand-revalidation/page.mdx
+++ b/docs/cache-handler-docs/src/app/usage/on-demand-revalidation/page.mdx
@@ -1,6 +1,6 @@
 # On-demand revalidation
 
-Next.js provides a way to revalidate a page or a result of a `fetch` call on demand. `@neshca/cache-handler` supports this feature with one limitation: `revalidatePath` only works for the Pages Router.
+Next.js provides a way to revalidate a page or a result of a `fetch` call on demand.
 
 ## Usage
 


### PR DESCRIPTION
Remove mention about `revalidatePath` not being supported in the App Router. It was introduced in https://github.com/caching-tools/next-shared-cache/pull/460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated on-demand revalidation documentation to clarify Next.js’ page and fetch call revalidation capabilities.
  - Removed references to previous limitations, ensuring the instructions now accurately reflect the current functionality.
  - Introduced additional documentation content to further support user understanding of these enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->