### PR TITLE
fix: apply keyPrefix in Redis handler delete methods

### DIFF
--- a/packages/cache-handler/src/handlers/experimental-redis-cluster.ts
+++ b/packages/cache-handler/src/handlers/experimental-redis-cluster.ts
@@ -260,7 +260,10 @@ export default function createHandler({
       await Promise.allSettled([...unlinkPromises, updateTagsOperation]);
     },
     async delete(key) {
-      await cluster.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
+      await cluster.unlink(
+        getTimeoutRedisCommandOptions(timeoutMs),
+        keyPrefix + key,
+      );
     },
   };
 }

--- a/packages/cache-handler/src/handlers/experimental-redis-cluster.ts
+++ b/packages/cache-handler/src/handlers/experimental-redis-cluster.ts
@@ -260,7 +260,7 @@ export default function createHandler({
       await Promise.allSettled([...unlinkPromises, updateTagsOperation]);
     },
     async delete(key) {
-      await cluster.unlink(getTimeoutRedisCommandOptions(timeoutMs), key);
+      await cluster.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
     },
   };
 }

--- a/packages/cache-handler/src/handlers/redis-stack.ts
+++ b/packages/cache-handler/src/handlers/redis-stack.ts
@@ -206,7 +206,7 @@ export default function createHandler({
       await client.unlink(options, keysToDelete);
     },
     async delete(key) {
-      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), key);
+      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
     },
   };
 }

--- a/packages/cache-handler/src/handlers/redis-stack.ts
+++ b/packages/cache-handler/src/handlers/redis-stack.ts
@@ -206,7 +206,10 @@ export default function createHandler({
       await client.unlink(options, keysToDelete);
     },
     async delete(key) {
-      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
+      await client.unlink(
+        getTimeoutRedisCommandOptions(timeoutMs),
+        keyPrefix + key,
+      );
     },
   };
 }

--- a/packages/cache-handler/src/handlers/redis-strings.ts
+++ b/packages/cache-handler/src/handlers/redis-strings.ts
@@ -222,7 +222,10 @@ export default function createHandler({
       await Promise.all([deleteKeysOperation, updateTagsOperation]);
     },
     async delete(key) {
-      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
+      await client.unlink(
+        getTimeoutRedisCommandOptions(timeoutMs),
+        keyPrefix + key,
+      );
     },
   };
 }

--- a/packages/cache-handler/src/handlers/redis-strings.ts
+++ b/packages/cache-handler/src/handlers/redis-strings.ts
@@ -222,7 +222,7 @@ export default function createHandler({
       await Promise.all([deleteKeysOperation, updateTagsOperation]);
     },
     async delete(key) {
-      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), key);
+      await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
     },
   };
 }


### PR DESCRIPTION
## Background

While studying this repository and learning about cache handlers, I noticed an inconsistency in the handler code. Although not critical for production use, I decided to submit this PR to fix the bug for completeness and consistency.

## Summary

Fixed a bug in the `delete` method of Redis cache handlers where `keyPrefix` was not being applied to cache keys, causing deletion attempts to target incorrect keys. This brings the `delete` method implementation in line with `get` and `set` methods.

### Issue

All three Redis handlers had the same bug in their delete method:

- `redis-strings.ts`
- `redis-stack.ts`
- `experimental-redis-cluster.ts`

```typescript
// ❌ Before
async delete(key: string) {
  await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), key);
}
```

While the `get` and `set` methods correctly use `keyPrefix + key`, the `delete` method was only using `key`, causing it to attempt deletion with an incorrect key.

```typescript
// ✅ After
async delete(key: string) {
  await client.unlink(getTimeoutRedisCommandOptions(timeoutMs), keyPrefix + key);
}
```

### Impact

**Low impact in production** - Redis handlers use TTL-based auto-eviction (EXAT/EXPIREAT), so expired entries are automatically removed by Redis itself. The `delete` method is optional and only intended for cache stores that don't support time-based key eviction (see Handler interface documentation).

**However, this bug prevented manual deletion from working correctly** when the `delete` method was explicitly called with a `keyPrefix` configuration.

### Changes

- Added `keyPrefix` to the key parameter in all three Redis handler `delete` methods
- Ensures consistency with `get` and `set` method implementations
- Maintains backward compatibility (no breaking changes)
