### PR TITLE
feat: add redis driver identification

### DIFF
--- a/.changeset/add-redis-driver-identification.md
+++ b/.changeset/add-redis-driver-identification.md
@@ -1,0 +1,6 @@
+---
+"@neshca/cache-handler": minor
+---
+
+Add getClientInfoTag helper for Redis client identification
+

--- a/apps/cache-testing/cache-handler-redis-stack.js
+++ b/apps/cache-testing/cache-handler-redis-stack.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const { CacheHandler } = require('@neshca/cache-handler');
+const { getClientInfoTag } = require('@neshca/cache-handler/helpers');
 const createLruHandler = require('@neshca/cache-handler/local-lru').default;
 const createRedisHandler = require('@neshca/cache-handler/redis-stack').default;
 const { createClient } = require('redis');
@@ -19,6 +20,7 @@ CacheHandler.onCreation(async () => {
     client = createClient({
       url: process.env.REDIS_URL,
       name: `cache-handler:${process.env.PORT ?? process.pid}`,
+      clientInfoTag: getClientInfoTag(),
     });
 
     // Redis won't work without error handling. https://github.com/redis/node-redis?tab=readme-ov-file#events

--- a/apps/cache-testing/cache-handler-redis-stack.mjs
+++ b/apps/cache-testing/cache-handler-redis-stack.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { CacheHandler } from '@neshca/cache-handler';
+import { getClientInfoTag } from '@neshca/cache-handler/helpers';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-stack';
 import { createClient } from 'redis';
@@ -19,6 +20,7 @@ CacheHandler.onCreation(async () => {
     client = createClient({
       url: process.env.REDIS_URL,
       name: `cache-handler:${process.env.PORT ?? process.pid}`,
+      clientInfoTag: getClientInfoTag(),
     });
 
     // Redis won't work without error handling. https://github.com/redis/node-redis?tab=readme-ov-file#events

--- a/apps/cache-testing/cache-handler-redis-strings.mjs
+++ b/apps/cache-testing/cache-handler-redis-strings.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { CacheHandler } from '@neshca/cache-handler';
+import { getClientInfoTag } from '@neshca/cache-handler/helpers';
 import createRedisHandler from '@neshca/cache-handler/redis-strings';
 import { createClient } from 'redis';
 
@@ -17,6 +18,7 @@ CacheHandler.onCreation(async () => {
   const client = createClient({
     url: process.env.REDIS_URL,
     name: `cache-handler:${PREFIX}${process.env.PORT ?? process.pid}`,
+    clientInfoTag: getClientInfoTag(),
   });
 
   // Redis won't work without error handling. https://github.com/redis/node-redis?tab=readme-ov-file#events

--- a/docs/cache-handler-docs/src/app/redis/page.mdx
+++ b/docs/cache-handler-docs/src/app/redis/page.mdx
@@ -10,6 +10,7 @@ Create a file called `cache-handler.mjs` next to your `next.config.js` with the 
 
 ```js filename="cache-handler.mjs" copy
 import { CacheHandler } from '@neshca/cache-handler';
+import { getClientInfoTag } from '@neshca/cache-handler/helpers';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import createRedisHandler from '@neshca/cache-handler/redis-stack';
 import { createClient } from 'redis';
@@ -21,6 +22,7 @@ CacheHandler.onCreation(async () => {
     // Create a Redis client.
     client = createClient({
       url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+      clientInfoTag: getClientInfoTag(),
     });
 
     // Redis won't work without error handling. https://github.com/redis/node-redis?tab=readme-ov-file#events

--- a/docs/cache-handler-docs/src/app/usage/creating-a-custom-handler/page.mdx
+++ b/docs/cache-handler-docs/src/app/usage/creating-a-custom-handler/page.mdx
@@ -18,13 +18,14 @@ Create a file called `cache-handler.mjs` next to your `next.config.js` with the 
 
 ```js filename="cache-handler.mjs" copy
 import { CacheHandler } from '@neshca/cache-handler';
-import { isImplicitTag } from '@neshca/cache-handler/helpers';
+import { getClientInfoTag, isImplicitTag } from '@neshca/cache-handler/helpers';
 import { createClient, commandOptions } from 'redis';
 
 CacheHandler.onCreation(async () => {
   // Always create a Redis client inside the `onCreation` callback.
   const client = createClient({
     url: 'redis://localhost:6379',
+    clientInfoTag: getClientInfoTag(),
   });
 
   // Redis won't work without error handling. https://github.com/redis/node-redis?tab=readme-ov-file#events

--- a/packages/cache-handler/src/helpers/get-client-info-tag.test.ts
+++ b/packages/cache-handler/src/helpers/get-client-info-tag.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getClientInfoTag } from './get-client-info-tag';
+
+await test('returns a string starting with neshca-cache-handler', () => {
+  const tag = getClientInfoTag();
+  assert.ok(
+    tag.startsWith('neshca-cache-handler'),
+    `Expected tag to start with "neshca-cache-handler", got "${tag}"`,
+  );
+});
+
+await test('returns tag with version when package.json is readable', () => {
+  const tag = getClientInfoTag();
+  // The tag should match the pattern neshca-cache-handler_vX.Y.Z
+  const versionPattern = /^neshca-cache-handler_v\d+\.\d+\.\d+$/;
+  assert.ok(
+    versionPattern.test(tag),
+    `Expected tag to match version pattern, got "${tag}"`,
+  );
+});
+
+await test('returns consistent results on multiple calls', () => {
+  const tag1 = getClientInfoTag();
+  const tag2 = getClientInfoTag();
+  assert.strictEqual(
+    tag1,
+    tag2,
+    'Expected getClientInfoTag to return consistent results',
+  );
+});
+
+await test('returns tag containing the actual package version', async () => {
+  const tag = getClientInfoTag();
+  // Read the actual version from package.json to verify
+  const { readFileSync } = await import('node:fs');
+  const { dirname, join } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = join(currentDir, '..', '..', 'package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    version: string;
+  };
+
+  assert.strictEqual(
+    tag,
+    `neshca-cache-handler_v${packageJson.version}`,
+    `Expected tag to contain version ${packageJson.version}`,
+  );
+});

--- a/packages/cache-handler/src/helpers/get-client-info-tag.ts
+++ b/packages/cache-handler/src/helpers/get-client-info-tag.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function getPackageVersion(): string | undefined {
+  try {
+    // ESM context
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const packageJsonPath = join(currentDir, '..', '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      version: string;
+    };
+    return packageJson.version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns a client info tag string for Redis client identification.
+ *
+ * This function reads the version from `@neshca/cache-handler/package.json`
+ * and returns a formatted string like `neshca-cache-handler_v1.9.0`.
+ *
+ * If the version cannot be read, it falls back to `neshca-cache-handler`.
+ *
+ * @example
+ * ```js
+ * import { createClient } from 'redis';
+ * import { getClientInfoTag } from '@neshca/cache-handler/helpers';
+ *
+ * const client = createClient({
+ *   url: 'redis://localhost:6379',
+ *   clientInfoTag: getClientInfoTag(),
+ * });
+ * ```
+ *
+ * @returns The client info tag string for Redis identification.
+ */
+export function getClientInfoTag(): string {
+  const version = getPackageVersion();
+  if (version) {
+    return `neshca-cache-handler_v${version}`;
+  }
+  return 'neshca-cache-handler';
+}

--- a/packages/cache-handler/src/helpers/helpers.ts
+++ b/packages/cache-handler/src/helpers/helpers.ts
@@ -1,3 +1,4 @@
 export { promiseWithTimeout } from './promise-with-timeout';
 export { isImplicitTag } from './is-implicit-tag';
 export { getTimeoutRedisCommandOptions } from './get-timeout-redis-command-options';
+export { getClientInfoTag } from './get-client-info-tag';


### PR DESCRIPTION
## Summary
Adds `getClientInfoTag` helper function for Redis driver identification.

## Changes
- Added `getClientInfoTag()` helper that returns a client info tag like `neshca-cache-handler_v1.9.0`
- Added tests for the helper
- Updated documentation examples to use the new helper

## Why
This helps identify the library using the Redis client in `CLIENT LIST` output, useful for debugging and monitoring Redis connections.

## Usage
```js
import { getClientInfoTag } from '@neshca/cache-handler/helpers';

const client = createClient({
  url: 'redis://localhost:6379',
  clientInfoTag: getClientInfoTag(),
});